### PR TITLE
[Datepicker] Fix CalendarDay faded prop

### DIFF
--- a/src/Inputs/Datepicker/Datebox.tsx
+++ b/src/Inputs/Datepicker/Datebox.tsx
@@ -180,7 +180,7 @@ const CalendarDay = styled.span<{
     margin: 2px;
     border-radius: 50%;
 
-    ${({ faded }): string => (faded ? 'opacity: 0.3' : '')}
+    ${({ faded }): string => (faded ? 'opacity: 0.3;' : '')}
     ${({ selected, theme }): string =>
         styledCondition(
             selected,


### PR DESCRIPTION
Closes #55

Test Plan:

1. Open Datepicker story
2. Observe that days not in this month are faded

Before:

![](https://user-images.githubusercontent.com/12089120/74596288-239c3400-501b-11ea-9fe3-1188b437c80e.png)

After:

![](https://user-images.githubusercontent.com/12089120/74596279-07989280-501b-11ea-8dd2-dff4630d6446.png)