### PR TITLE
CEENG-263 Add MaskedInput component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .deploy
 .awcache
 dist
+.idea

--- a/src/Fragments/InputFragment.tsx
+++ b/src/Fragments/InputFragment.tsx
@@ -6,14 +6,15 @@ import { ResponsiveInterface, MainInterface } from '@Utils/BaseStyles';
 interface InputFragmentProps extends ResponsiveInterface, MainInterface {
     disabled?: boolean;
     placeholder?: string;
-    onChange?: React.ChangeEventHandler<HTMLElement>;
+    onChange?: React.ChangeEventHandler<HTMLInputElement>;
     value?: string | number;
     error?: boolean;
     success?: boolean;
     children?: React.ReactNode;
-    onFocus?: React.FocusEventHandler<HTMLElement>;
-    onKeyDown?: React.KeyboardEventHandler<HTMLElement>;
-    onClick?: React.MouseEventHandler<HTMLElement>;
+    onFocus?: React.FocusEventHandler<HTMLInputElement>;
+    onBlur?: React.FocusEventHandler<HTMLInputElement>;
+    onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>;
+    onClick?: React.MouseEventHandler<HTMLInputElement>;
     className?: string;
 }
 

--- a/src/Inputs/MaskedInput.tsx
+++ b/src/Inputs/MaskedInput.tsx
@@ -9,6 +9,28 @@ export interface MaskedInputProps extends LabelLayoutProps {
     mask: (value: string) => string;
 }
 
+export const DOLLAR_FORMAT_MASK = (s: string): string => {
+    const number = +s;
+    if (Number.isNaN(number)) {
+        return 'Invalid value.';
+    }
+    if (number < 0) {
+        return `-$${-number.toFixed(2)}`;
+    }
+    return `$${number.toFixed(2)}`;
+};
+
+export const PERCENT_FORMAT_MASK = (s: string): string => {
+    const number = +s;
+    if (Number.isNaN(number)) {
+        return 'Invalid value.';
+    }
+    if (number < 0) {
+        return `-${-number.toFixed(0)}%`;
+    }
+    return `${number.toFixed(0)}%`;
+};
+
 export const MaskedInput: React.FC<MaskedInputProps> = ({
     mask,
     realValue,

--- a/src/Inputs/MaskedInput.tsx
+++ b/src/Inputs/MaskedInput.tsx
@@ -1,0 +1,52 @@
+import React, { useState, useEffect } from 'react';
+import { LabelLayout, LabelLayoutProps, InputFragment } from '@Layouts';
+
+export interface MaskedInputProps extends LabelLayoutProps {
+    disabled?: boolean;
+    placeholder?: string;
+    realValue: string;
+    onRealValueChange: (value: string) => void;
+    mask: (value: string) => string;
+}
+
+export const MaskedInput: React.FC<MaskedInputProps> = ({
+    mask,
+    realValue,
+    onRealValueChange,
+    ...props
+}): React.ReactElement => {
+    const [displayValue, setDisplayValue] = useState(mask(realValue));
+    const [isFocused, setIsFocused] = useState(false);
+
+    useEffect((): void => {
+        if (isFocused) {
+            setDisplayValue(realValue);
+        } else {
+            setDisplayValue(mask(realValue));
+        }
+    }, [realValue]);
+
+    return (
+        <LabelLayout {...props}>
+            <InputFragment
+                value={displayValue}
+                onFocus={(): void => {
+                    setIsFocused(true);
+                    setDisplayValue(realValue);
+                }}
+                onBlur={(): void => {
+                    setIsFocused(false);
+                    setDisplayValue(mask(realValue));
+                }}
+                onChange={(e): void => {
+                    if (isFocused) {
+                        onRealValueChange(e.target.value);
+                    }
+                }}
+                {...props}
+            />
+        </LabelLayout>
+    );
+};
+
+export default MaskedInput;

--- a/src/Inputs/index.ts
+++ b/src/Inputs/index.ts
@@ -13,3 +13,4 @@ export * from './Image';
 export * from './ExcelOptions';
 export * from './EmojiPicker';
 export * from './ColorPicker';
+export * from './MaskedInput';

--- a/stories/Inputs/MaskedInput.stories.js
+++ b/stories/Inputs/MaskedInput.stories.js
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import { storiesOf } from '@storybook/react';
+import { withKnobs, text } from '@storybook/addon-knobs';
+import MaskedInput from '../../src/Inputs/MaskedInput';
+
+storiesOf('FormattedInput', module)
+    .addDecorator(withKnobs)
+    .add('with dollar formatter', () => {
+        const [value, setValue] = useState('90');
+        return (
+            <MaskedInput
+                name="demo"
+                label={text('Enter a value', 'Enter a value')}
+                placeholder={text('Enter a value', 'Enter a value')}
+                description={text('Enter a value', 'Enter a value')}
+                realValue={value}
+                onRealValueChange={setValue}
+                mask={s => '$' + s}
+            />
+        );
+    })
+    .add('with percentage formatter', () => {
+        const [value, setValue] = useState('0');
+        return (
+            <MaskedInput
+                name="demo"
+                label={text('Enter a number', 'Enter a number')}
+                description={text(
+                    'Enter a number below',
+                    'Enter a number below',
+                )}
+                placeholder={text('10.00', '10.00')}
+                realValue={value}
+                onRealValueChange={setValue}
+                mask={s => s + '%'}
+            />
+        );
+    });

--- a/stories/Inputs/MaskedInput.stories.js
+++ b/stories/Inputs/MaskedInput.stories.js
@@ -1,9 +1,12 @@
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, text } from '@storybook/addon-knobs';
-import MaskedInput from '../../src/Inputs/MaskedInput';
+import MaskedInput, {
+    DOLLAR_FORMAT_MASK,
+    PERCENT_FORMAT_MASK,
+} from '../../src/Inputs/MaskedInput';
 
-storiesOf('FormattedInput', module)
+storiesOf('MaskedInput', module)
     .addDecorator(withKnobs)
     .add('with dollar formatter', () => {
         const [value, setValue] = useState('90');
@@ -15,7 +18,7 @@ storiesOf('FormattedInput', module)
                 description={text('Enter a value', 'Enter a value')}
                 realValue={value}
                 onRealValueChange={setValue}
-                mask={s => '$' + s}
+                mask={DOLLAR_FORMAT_MASK}
             />
         );
     })
@@ -32,7 +35,7 @@ storiesOf('FormattedInput', module)
                 placeholder={text('10.00', '10.00')}
                 realValue={value}
                 onRealValueChange={setValue}
-                mask={s => s + '%'}
+                mask={PERCENT_FORMAT_MASK}
             />
         );
     });

--- a/stories/Inputs/MaskedInput.stories.js
+++ b/stories/Inputs/MaskedInput.stories.js
@@ -1,10 +1,7 @@
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, text } from '@storybook/addon-knobs';
-import MaskedInput, {
-    DOLLAR_FORMAT_MASK,
-    PERCENT_FORMAT_MASK,
-} from '../../src/Inputs/MaskedInput';
+import { MaskedInputPreset, MaskedInput } from '../../src/Inputs';
 
 storiesOf('MaskedInput', module)
     .addDecorator(withKnobs)
@@ -18,7 +15,7 @@ storiesOf('MaskedInput', module)
                 description={text('Enter a value', 'Enter a value')}
                 realValue={value}
                 onRealValueChange={setValue}
-                mask={DOLLAR_FORMAT_MASK}
+                mask={MaskedInputPreset.DOLLAR}
             />
         );
     })
@@ -35,7 +32,21 @@ storiesOf('MaskedInput', module)
                 placeholder={text('10.00', '10.00')}
                 realValue={value}
                 onRealValueChange={setValue}
-                mask={PERCENT_FORMAT_MASK}
+                mask={MaskedInputPreset.PERCENTAGE}
+            />
+        );
+    })
+    .add('with sensitive info hider', () => {
+        const [value, setValue] = useState('some sensitive info');
+        return (
+            <MaskedInput
+                name="demo"
+                label={text('Enter a value', 'Enter a value')}
+                description={text('Enter a value below', 'Enter a value below')}
+                placeholder={text('10.00', '10.00')}
+                realValue={value}
+                onRealValueChange={setValue}
+                mask={() => '*****'}
             />
         );
     });


### PR DESCRIPTION
Masked input takes in a mask function, and uses abstracted value/onChange handlers to handle events.

```
<MaskedInput
         name="demo"
         label={text('Enter a value', 'Enter a value')}
         placeholder={text('Enter a value', 'Enter a value')}
         description={text('Enter a value', 'Enter a value')}
         realValue={value}
         onRealValueChange={setValue}
         mask={s => '$' + s}
/>      
```

There are two preset masks

```
DOLLAR_FORMAT_MASK
PERCENT_FORMAT_MASK
```

there are also no error handling because input already have props to pass-in errors, applications should have its own logic to handle errors (for example you might actually want to enable 120%, I don't want to restrict that, also you might still want to have advanced custom error handling, that cannot be baked into SDK).

![2020-03-19 00 00 02](https://user-images.githubusercontent.com/7855724/77030420-dd692600-6974-11ea-8f64-90dc3dfab45c.gif)

**Want approval from all**