### PR TITLE
CEENG-312 Update React UI with HTML Attributes

### DIFF
--- a/src/Containers/Card.tsx
+++ b/src/Containers/Card.tsx
@@ -8,7 +8,7 @@ import {
 import { transition } from '@Utils/Mixins';
 import styled from 'styled-components';
 
-export interface CardProps {
+export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
     animated?: boolean;
     flat?: boolean;
 }

--- a/src/Containers/Copyright.tsx
+++ b/src/Containers/Copyright.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 import { MainInterface, ResponsiveInterface } from '@Utils/BaseStyles';
 import { SmallText } from '../Text/SmallText';
 
-interface CopyrightProps extends MainInterface, ResponsiveInterface {
+interface CopyrightProps
+    extends MainInterface,
+        ResponsiveInterface,
+        React.HTMLAttributes<HTMLParagraphElement> {
     margin: string;
     version: string | number;
 }

--- a/src/Containers/Footnote.tsx
+++ b/src/Containers/Footnote.tsx
@@ -9,7 +9,10 @@ import {
 import { flex, position as pos, scroll, transition } from '@Utils/Mixins';
 import { useTransition } from '@Utils/Hooks';
 
-export interface FootnoteProps extends MainInterface, ResponsiveInterface {
+export interface FootnoteProps
+    extends MainInterface,
+        ResponsiveInterface,
+        React.HTMLAttributes<HTMLDivElement> {
     show?: boolean;
     theme: DefaultTheme;
     position?: 'absolute' | 'fixed';

--- a/src/Containers/ImageCarousel.tsx
+++ b/src/Containers/ImageCarousel.tsx
@@ -8,8 +8,7 @@ import { ImplicitPropsInterface } from '@Utils/Hooks';
 export interface ImageCarouselProps
     extends MainInterface,
         ResponsiveInterface,
-        // doesn't work for some reason - havent been able to find a solution
-        // React.HTMLAttributes<HTMLUListElement>,
+        Omit<React.HTMLAttributes<HTMLUListElement>, 'onClick'>,
         ImplicitPropsInterface {
     imageData: string[];
     onClick: Function;

--- a/src/Containers/ImageCarousel.tsx
+++ b/src/Containers/ImageCarousel.tsx
@@ -8,6 +8,8 @@ import { ImplicitPropsInterface } from '@Utils/Hooks';
 export interface ImageCarouselProps
     extends MainInterface,
         ResponsiveInterface,
+        // doesn't work for some reason - havent been able to find a solution
+        // React.HTMLAttributes<HTMLUListElement>,
         ImplicitPropsInterface {
     imageData: string[];
     onClick: Function;

--- a/src/Containers/List.tsx
+++ b/src/Containers/List.tsx
@@ -13,7 +13,10 @@ interface ItemProps {
     [name: string]: object | string | boolean | Function | number;
 }
 
-export interface ListProps extends MainInterface, ResponsiveInterface {
+export interface ListProps
+    extends MainInterface,
+        ResponsiveInterface,
+        React.HTMLAttributes<HTMLDivElement> {
     loading: boolean;
     render: Function;
     items?: object[];

--- a/src/Containers/Modal.tsx
+++ b/src/Containers/Modal.tsx
@@ -10,7 +10,10 @@ import {
 } from '@Utils/BaseStyles';
 import { useTransition } from '@Utils/Hooks';
 
-export interface ModalProps extends ResponsiveInterface, MainInterface {
+export interface ModalProps
+    extends ResponsiveInterface,
+        MainInterface,
+        React.HTMLAttributes<HTMLDivElement> {
     theme: DefaultTheme;
     onClose?: Function;
     width?: string | number;

--- a/src/Containers/Navigation.tsx
+++ b/src/Containers/Navigation.tsx
@@ -23,6 +23,7 @@ interface NavProps {
     icon: React.ForwardRefExoticComponent<React.RefAttributes<SVGSVGElement>>;
 }
 
+// no HTMLNavigationElement
 export interface NavigationProps extends MainInterface, ResponsiveInterface {
     params?: { [name: string]: string };
     pages?: [

--- a/src/Containers/NavigationFootnote.tsx
+++ b/src/Containers/NavigationFootnote.tsx
@@ -9,7 +9,8 @@ import { Paragraph as P } from '../Text';
 export interface NavigationFootnoteProps
     extends MainInterface,
         ResponsiveInterface,
-        ImplicitPropsInterface {
+        ImplicitPropsInterface,
+        React.HTMLAttributes<HTMLDivElement> {
     url: string;
     text: string;
 }

--- a/src/Containers/SettingsCard.tsx
+++ b/src/Containers/SettingsCard.tsx
@@ -6,7 +6,10 @@ import { Mixins } from '@Utils';
 import { Card as C } from './Card';
 import { Heading } from '../Text';
 
-interface SettingsCardProps extends MainInterface, ResponsiveInterface {
+interface SettingsCardProps
+    extends MainInterface,
+        ResponsiveInterface,
+        React.HTMLAttributes<HTMLDivElement> {
     heading: string;
     icon: StyledIcon;
 }

--- a/src/Containers/Tag.tsx
+++ b/src/Containers/Tag.tsx
@@ -4,7 +4,7 @@ import { Times } from 'styled-icons/fa-solid/Times';
 import { flex, darken, transition, clickable } from '@Utils/Mixins';
 import { Main } from '@Utils/BaseStyles';
 
-export interface TagProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface TagProps extends React.HTMLAttributes<HTMLSpanElement> {
     icon?: React.ForwardRefExoticComponent<React.RefAttributes<SVGSVGElement>>;
 }
 

--- a/src/Fragments/InputFragment.tsx
+++ b/src/Fragments/InputFragment.tsx
@@ -3,7 +3,10 @@ import styled from 'styled-components';
 import { transition, styledCondition } from '@Utils/Mixins';
 import { ResponsiveInterface, MainInterface } from '@Utils/BaseStyles';
 
-interface InputFragmentProps extends ResponsiveInterface, MainInterface {
+interface InputFragmentProps
+    extends ResponsiveInterface,
+        MainInterface,
+        React.HTMLAttributes<HTMLInputElement> {
     disabled?: boolean;
     placeholder?: string;
     onChange?: React.ChangeEventHandler<HTMLInputElement>;

--- a/src/Fragments/TextLayout.tsx
+++ b/src/Fragments/TextLayout.tsx
@@ -7,7 +7,10 @@ import {
     ResponsiveInterface,
 } from '@Utils/BaseStyles';
 
-export interface TextLayoutProps extends MainInterface, ResponsiveInterface {
+export interface TextLayoutProps
+    extends MainInterface,
+        ResponsiveInterface,
+        React.HTMLAttributes<HTMLParagraphElement> {
     color?: string;
     lineHeight?: number | string;
     bold?: boolean;

--- a/src/Inputs/Button.tsx
+++ b/src/Inputs/Button.tsx
@@ -10,7 +10,10 @@ import {
 import { transition, clickable, position, flex } from '@Utils/Mixins';
 import { useTransition } from '@Utils/Hooks';
 
-export interface ButtonProps extends MainInterface, ResponsiveInterface {
+export interface ButtonProps
+    extends MainInterface,
+        ResponsiveInterface,
+        React.HTMLAttributes<HTMLButtonElement> {
     icon?: React.ForwardRefExoticComponent<React.RefAttributes<SVGSVGElement>>;
     color?: string;
     primary?: boolean;

--- a/src/Inputs/Checkbox.tsx
+++ b/src/Inputs/Checkbox.tsx
@@ -15,7 +15,8 @@ import { position, darken, flex, transition } from '@Utils/Mixins';
 export interface CheckboxProps
     extends MainInterface,
         ResponsiveInterface,
-        ImplicitPropsInterface {
+        ImplicitPropsInterface,
+        React.HTMLAttributes<HTMLDivElement> {
     label?: string;
     column?: boolean;
     className?: string;

--- a/src/Inputs/Datepicker/Datebox.tsx
+++ b/src/Inputs/Datepicker/Datebox.tsx
@@ -63,7 +63,7 @@ const buildCalendar = (
     return items;
 };
 
-export interface DateboxProps {
+export interface DateboxProps extends React.HTMLAttributes<HTMLDivElement> {
     changePage: (change?: number) => React.MouseEventHandler;
     selectedDate?: Date;
     selectDate: React.MouseEventHandler;

--- a/src/Inputs/ExcelOptions.tsx
+++ b/src/Inputs/ExcelOptions.tsx
@@ -18,7 +18,8 @@ import { Mixins } from '../Utils';
 export interface ExcelOptionsProps
     extends MainInterface,
         ResponsiveInterface,
-        ImplicitPropsInterface {
+        ImplicitPropsInterface,
+        React.HTMLAttributes<HTMLDivElement> {
     headers: string[];
     defaultHeaders: string[];
     onResult?: Function;

--- a/src/Inputs/MutliSelect/MultiSelect.tsx
+++ b/src/Inputs/MutliSelect/MultiSelect.tsx
@@ -4,7 +4,9 @@ import { flex } from '@Utils/Mixins';
 import { LabelLayout, LabelLayoutProps } from '../../Fragments/LabelLayout';
 import { MultiSelectContext } from './MultiSelectContext';
 
-export interface MultiSelectProps extends LabelLayoutProps {
+export interface MultiSelectProps
+    extends LabelLayoutProps,
+        React.HTMLAttributes<HTMLDivElement> {
     columns?: string | number;
 }
 

--- a/src/Inputs/Radio.tsx
+++ b/src/Inputs/Radio.tsx
@@ -14,7 +14,8 @@ import { position, darken, flex, transition } from '@Utils/Mixins';
 export interface RadioProps
     extends MainInterface,
         ResponsiveInterface,
-        ImplicitPropsInterface {
+        ImplicitPropsInterface,
+        React.HTMLAttributes<HTMLDivElement> {
     label?: string;
     column?: boolean;
     className?: string;

--- a/src/__Layouts/LabelLayout.tsx
+++ b/src/__Layouts/LabelLayout.tsx
@@ -18,7 +18,8 @@ import { flex, transition } from '@Utils/Mixins';
 export interface LabelLayoutProps
     extends ResponsiveInterface,
         MainInterface,
-        ImplicitPropsInterface {
+        ImplicitPropsInterface,
+        React.HTMLAttributes<HTMLDivElement> {
     name?: string;
     label?: string;
     description?: string;

--- a/src/__Layouts/TextLayout.tsx
+++ b/src/__Layouts/TextLayout.tsx
@@ -7,7 +7,10 @@ import {
     ResponsiveInterface,
 } from '@Utils/BaseStyles';
 
-export interface TextLayoutProps extends MainInterface, ResponsiveInterface {
+export interface TextLayoutProps
+    extends MainInterface,
+        ResponsiveInterface,
+        React.HTMLAttributes<HTMLParagraphElement> {
     color?: string;
     lineHeight?: number | string;
     bold?: boolean;


### PR DESCRIPTION
I have updated as many of the components as I could with the HTML attributes. There were some issues where a component uses a "custom" onChange function but because it is also called onChange it throws an error when you try to extend an HTML interface. 