### PR TITLE
CEM-725-Modify-Image-Carousel-Component

### DIFF
--- a/src/Containers/ImageCarousel.tsx
+++ b/src/Containers/ImageCarousel.tsx
@@ -11,7 +11,11 @@ export interface ImageCarouselProps
         Omit<React.HTMLAttributes<HTMLUListElement>, 'onClick'>,
         ImplicitPropsInterface {
     imageData: string[];
+    pointer:boolean;
     onClick: Function;
+    icon:boolean;
+    overlay:boolean;
+    overlayText:string;
     altText: string;
     width?: number;
     height?: number;
@@ -20,6 +24,10 @@ export interface ImageCarouselProps
 export const ImageCarousel: React.FC<ImageCarouselProps> = ({
     imageData,
     onClick,
+    pointer,
+    icon,
+    overlay,
+    overlayText,
     altText,
     width = 150,
     height = 75,
@@ -28,10 +36,12 @@ export const ImageCarousel: React.FC<ImageCarouselProps> = ({
     return (
         <Items {...props}>
             {imageData.map(image => (
-                <Item key={image} onClick={() => onClick(image)}>
-                    <Overlay>
-                        <Icon /> Delete
-                    </Overlay>
+                <Item key={image} onClick={() => onClick(image)} cursor={pointer}>
+                    {overlay &&
+                        <Overlay>
+                        {icon && <Icon />} {overlayText}
+                        </Overlay>
+                    }
                     <img
                         width={width}
                         height={height}
@@ -44,6 +54,10 @@ export const ImageCarousel: React.FC<ImageCarouselProps> = ({
     );
 };
 
+interface StyledItemProps {
+    cursor: boolean;
+}
+
 const Items = styled.ul`
     ${flex()}
     ${scroll}
@@ -53,7 +67,7 @@ const Items = styled.ul`
     margin: 15px 0 0;
 `;
 
-const Item = styled.li`
+const Item = styled.li<StyledItemProps>`
     ${transition(['background-color'])}
     ${flex('row', 'center')}
     position: relative;
@@ -61,7 +75,7 @@ const Item = styled.li`
     margin: 0 7px 7px 0;
     box-shadow: 0 0 3px rgba(0, 0, 0, 0.3);
     flex-shrink: 0;
-    cursor: pointer;
+    cursor: ${({ cursor }): {} => cursor ? "pointer": ""};
     overflow: hidden;
 `;
 

--- a/src/Containers/ImageCarousel.tsx
+++ b/src/Containers/ImageCarousel.tsx
@@ -11,11 +11,13 @@ export interface ImageCarouselProps
         Omit<React.HTMLAttributes<HTMLUListElement>, 'onClick'>,
         ImplicitPropsInterface {
     imageData: string[];
-    pointer:boolean;
+    pointer: boolean;
     onClick: Function;
-    icon:boolean;
-    overlay:boolean;
-    overlayText:string;
+    hoverIcon: React.ForwardRefExoticComponent<
+        React.RefAttributes<SVGSVGElement>
+    >;
+    hoverOverlay: boolean;
+    hoverText: string;
     altText: string;
     width?: number;
     height?: number;
@@ -24,10 +26,10 @@ export interface ImageCarouselProps
 export const ImageCarousel: React.FC<ImageCarouselProps> = ({
     imageData,
     onClick,
-    pointer,
-    icon,
-    overlay,
-    overlayText,
+    pointer = true,
+    hoverIcon = Times,
+    hoverOverlay = true,
+    hoverText = 'Delete',
     altText,
     width = 150,
     height = 75,
@@ -36,12 +38,16 @@ export const ImageCarousel: React.FC<ImageCarouselProps> = ({
     return (
         <Items {...props}>
             {imageData.map(image => (
-                <Item key={image} onClick={() => onClick(image)} cursor={pointer}>
-                    {overlay &&
+                <Item
+                    key={image}
+                    onClick={() => onClick(image)}
+                    cursor={pointer}
+                >
+                    {hoverOverlay && (
                         <Overlay>
-                        {icon && <Icon />} {overlayText}
+                            <Icon as={hoverIcon} /> {hoverText}
                         </Overlay>
-                    }
+                    )}
                     <img
                         width={width}
                         height={height}
@@ -75,7 +81,7 @@ const Item = styled.li<StyledItemProps>`
     margin: 0 7px 7px 0;
     box-shadow: 0 0 3px rgba(0, 0, 0, 0.3);
     flex-shrink: 0;
-    cursor: ${({ cursor }): {} => cursor ? "pointer": ""};
+    cursor: ${({ cursor }): {} => (cursor ? 'pointer' : '')};
     overflow: hidden;
 `;
 
@@ -96,7 +102,7 @@ const Overlay = styled.div`
     }
 `;
 
-const Icon = styled(Times)`
+const Icon = styled.svg`
     width: 16px;
     height: 16px;
     margin-right: 3px;

--- a/stories/Containers/ImageCarousel.stories.js
+++ b/stories/Containers/ImageCarousel.stories.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withKnobs } from '@storybook/addon-knobs';
 import { ImageCarousel } from '../../src';
+import {Plus} from "@styled-icons/boxicons-regular/Plus";
 
 const images = [
     'https://image.shutterstock.com/image-photo/image-250nw-1081879181.jpg',
@@ -14,11 +15,7 @@ storiesOf('Image Carousel', module)
     .add('with default', () => (
         <ImageCarousel
             imageData={images}
-            pointer
-            onClick={() => console.log('Clicked!')}
-            icon
-            overlay
-            overlayText="Editable Text"
             altText="Funny Image"
+            onClick={() => console.log('Clicked!')}
         ></ImageCarousel>
     ));

--- a/stories/Containers/ImageCarousel.stories.js
+++ b/stories/Containers/ImageCarousel.stories.js
@@ -14,7 +14,11 @@ storiesOf('Image Carousel', module)
     .add('with default', () => (
         <ImageCarousel
             imageData={images}
-            altText="Funny Image"
+            pointer
             onClick={() => console.log('Clicked!')}
+            icon
+            overlay
+            overlayText="Editable Text"
+            altText="Funny Image"
         ></ImageCarousel>
     ));


### PR DESCRIPTION
Modified the ImageCarousel Component to be able to accept additional props to increase flexibility.

ImageCarousel can accept overlay, overlayText, icon, and pointer as props.

![CEM-725-Modify-Image-Carousel](https://user-images.githubusercontent.com/29719870/87596967-d5f92580-c6a5-11ea-9128-88fc9897d810.png)
