### PR TITLE
CEM 909 KitchenCard StatusModifier

### DIFF
--- a/src/Containers/KitchenCard/KitchenCard.tsx
+++ b/src/Containers/KitchenCard/KitchenCard.tsx
@@ -30,6 +30,7 @@ export interface KitchenProps {
     cardWidth: number;
     cardMargin: number;
     TimeComponent: React.ReactNode | string;
+    StatusModifierComponent: React.ReactNode | string;
 }
 
 export const KitchenCard: React.FC<KitchenProps> = ({
@@ -45,6 +46,7 @@ export const KitchenCard: React.FC<KitchenProps> = ({
     cardWidth,
     cardMargin,
     TimeComponent,
+    StatusModifierComponent,
 }): React.ReactElement => {
     return (
         <Card
@@ -77,6 +79,7 @@ export const KitchenCard: React.FC<KitchenProps> = ({
                 modifiers={modifiers}
                 isFullName={isFullName}
             />
+            {StatusModifierComponent}
         </Card>
     );
 };

--- a/stories/Containers/KitchenCard.stories.js
+++ b/stories/Containers/KitchenCard.stories.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, text, boolean, array } from '@storybook/addon-knobs';
 import { KitchenCard } from '../../src';
+import {Button} from '../../src/Inputs/Button'
+import styled from 'styled-components';
 
 const sampleOrder = {
     _id: '5f15ff0d1689a01c4b9cc72f',
@@ -56,6 +58,9 @@ const sampleOrderMany = {
     order_type: 'EAT_IN',
 };
 
+const StatusModifierComponent = <><Button loading={false} margin="0 6px 5px 0">Hello</Button><Button loading={false} margin="0 6px 0 0">Hello</Button></>
+
+
 storiesOf('KitchenCard', module)
     .addDecorator(withKnobs)
     .add('with default', () => (
@@ -69,6 +74,7 @@ storiesOf('KitchenCard', module)
             ]}
             isFullName={boolean('displayFullName', false)}
             TimeComponent={text('Time', '10:00')}
+            orderType={sampleOrder.order_type}
             {...sampleOrder}
         />
     ))
@@ -83,6 +89,7 @@ storiesOf('KitchenCard', module)
             ]}
             isFullName={boolean('displayFullName', true)}
             TimeComponent={text('Time', '10:00')}
+            orderType={sampleOrder.order_type}
             {...sampleOrder}
         />
     ))
@@ -102,6 +109,28 @@ storiesOf('KitchenCard', module)
             ]}
             isFullName={boolean('displayFullName', true)}
             TimeComponent={text('Time', '10:00')}
+            orderType={sampleOrder.order_type}
+            {...sampleOrderMany}
+        />
+    ))
+    .add('StatusModifier Component', () => (
+        <KitchenCard
+            cardWidth={230}
+            cardMargin={10}
+            cardHeight={400}
+            modifiers={[
+                ['Add Lettuce', 'Mayo'],
+                ['No Ketchup', 'Add Bacon', 'Add Olives'],
+                [],
+                ['Add Lettuce'],
+                [],
+                ['No Ketchup'],
+                [],
+            ]}
+            isFullName={boolean('displayFullName', true)}
+            TimeComponent={text('Time', '10:00')}
+            StatusModifierComponent={StatusModifierComponent}
+            orderType={sampleOrder.order_type}
             {...sampleOrderMany}
         />
     ));

--- a/stories/Containers/KitchenCard.stories.js
+++ b/stories/Containers/KitchenCard.stories.js
@@ -3,7 +3,6 @@ import { storiesOf } from '@storybook/react';
 import { withKnobs, text, boolean, array } from '@storybook/addon-knobs';
 import { KitchenCard } from '../../src';
 import {Button} from '../../src/Inputs/Button'
-import styled from 'styled-components';
 
 const sampleOrder = {
     _id: '5f15ff0d1689a01c4b9cc72f',


### PR DESCRIPTION
Modified KitchenCard to accept a component for modifying the status of the order.

Fixed storybook to change order_type to orderType and added story for StatusModifier.

![CEM-909-KitchenCard-StatusModifier-TwoButtons](https://user-images.githubusercontent.com/29719870/91093367-2ef59b00-e60e-11ea-94f0-e2e94101fb88.png)
