### PR TITLE
CEM-911-Fix-LabelLayout-Error-Display

### DIFF
--- a/src/Fragments/InputFragment.tsx
+++ b/src/Fragments/InputFragment.tsx
@@ -53,12 +53,12 @@ const InputElement = styled.input<InputFragmentProps>`
     // Background color
     ${({ theme, error = false, success = false }): string => `
         background-color: ${styledCondition(
-            error,
-            theme.colors.input.error,
-            success,
-            theme.colors.input.success,
-            theme.colors.input.default,
-        )};
+        error,
+        theme.colors.input.error,
+        success,
+        theme.colors.input.success,
+        theme.colors.input.default,
+    )};
     `}
 `;
 

--- a/src/Fragments/InputFragment.tsx
+++ b/src/Fragments/InputFragment.tsx
@@ -11,7 +11,7 @@ export interface InputFragmentProps
     placeholder?: string;
     onChange?: React.ChangeEventHandler<HTMLInputElement>;
     value?: string | number;
-    error?: boolean;
+    error?: boolean | string;
     success?: boolean;
     children?: React.ReactNode;
     onFocus?: React.FocusEventHandler<HTMLInputElement>;

--- a/src/Fragments/LabelLayout.tsx
+++ b/src/Fragments/LabelLayout.tsx
@@ -22,8 +22,7 @@ export interface LabelLayoutProps
     name?: string;
     label?: string;
     description?: string;
-    error?: boolean;
-    errorMessage?:string;
+    error?: boolean | string;
     success?: boolean;
     className?: string;
     children?: React.ReactNode;
@@ -39,7 +38,6 @@ export const LabelLayout: React.ForwardRefExoticComponent<LabelLayoutProps> = fo
             label,
             description,
             error,
-            errorMessage,
             success,
             children,
             className,
@@ -47,7 +45,7 @@ export const LabelLayout: React.ForwardRefExoticComponent<LabelLayoutProps> = fo
         },
         ref,
     ): React.ReactElement => {
-        const [, mount, animation] = useTransition(error, {
+        const [, mount, animation] = useTransition(!!error, {
             end: 250,
         });
         const implicitProps = __useImplicitProps(props, [
@@ -67,7 +65,7 @@ export const LabelLayout: React.ForwardRefExoticComponent<LabelLayoutProps> = fo
                 {children}
                 {mount && (
                     <ErrorLabel id={`${name}-error`} error={animation}>
-                        {errorMessage}
+                        {error}
                     </ErrorLabel>
                 )}
             </Layout>

--- a/src/Fragments/LabelLayout.tsx
+++ b/src/Fragments/LabelLayout.tsx
@@ -23,6 +23,7 @@ export interface LabelLayoutProps
     label?: string;
     description?: string;
     error?: boolean;
+    errorMessage?:string;
     success?: boolean;
     className?: string;
     children?: React.ReactNode;
@@ -38,6 +39,7 @@ export const LabelLayout: React.ForwardRefExoticComponent<LabelLayoutProps> = fo
             label,
             description,
             error,
+            errorMessage,
             success,
             children,
             className,
@@ -45,7 +47,9 @@ export const LabelLayout: React.ForwardRefExoticComponent<LabelLayoutProps> = fo
         },
         ref,
     ): React.ReactElement => {
-        const [, _error] = useTransition(error, { end: 250 });
+        const [, mount, animation] = useTransition(error, {
+            end: 250,
+        });
         const implicitProps = __useImplicitProps(props, [
             ...MainProps,
             ...ResponsiveProps,
@@ -61,9 +65,11 @@ export const LabelLayout: React.ForwardRefExoticComponent<LabelLayoutProps> = fo
                 {label && <Label htmlFor={name}>{label}</Label>}
                 {description && <Info id={`${name}-info`}>{description}</Info>}
                 {children}
-                <ErrorLabel id={`${name}-error`} error={error}>
-                    {_error}
-                </ErrorLabel>
+                {mount && (
+                    <ErrorLabel id={`${name}-error`} error={animation}>
+                        {errorMessage}
+                    </ErrorLabel>
+                )}
             </Layout>
         );
     },

--- a/stories/Inputs/Input.stories.js
+++ b/stories/Inputs/Input.stories.js
@@ -11,6 +11,7 @@ storiesOf('Input', module)
             label={text('Label', 'Label')}
             description={text('Description', 'Description')}
             placeholder={text('Placeholder', 'Placeholder')}
+            
         />
     ))
     .add('with success', () => (
@@ -28,7 +29,8 @@ storiesOf('Input', module)
             label="Label"
             description="This is an input with an error message"
             placeholder="Placeholder"
-            error={text('Error Message', 'Error Message!')}
+            error={boolean('error', false)}
+            errorMessage={text('error message', 'Error')}
         />
     ))
     .add('with disabled', () => (
@@ -37,7 +39,8 @@ storiesOf('Input', module)
             label="Label"
             description="This is a disabled input"
             placeholder="Placeholder"
-            error={text('Error Message')}
+            error={boolean('error', false)}
+            errorMessage={text('error message', 'Error')}
             disabled={boolean('Disabled', true)}
             success={boolean('Success', false)}
         />

--- a/stories/Inputs/Input.stories.js
+++ b/stories/Inputs/Input.stories.js
@@ -29,8 +29,7 @@ storiesOf('Input', module)
             label="Label"
             description="This is an input with an error message"
             placeholder="Placeholder"
-            error={boolean('error', false)}
-            errorMessage={text('error message', 'Error')}
+            error={text('error', 'error')}
         />
     ))
     .add('with disabled', () => (
@@ -39,8 +38,7 @@ storiesOf('Input', module)
             label="Label"
             description="This is a disabled input"
             placeholder="Placeholder"
-            error={boolean('error', false)}
-            errorMessage={text('error message', 'Error')}
+            error={text('error', "error")}
             disabled={boolean('Disabled', true)}
             success={boolean('Success', false)}
         />

--- a/stories/Inputs/Input.stories.js
+++ b/stories/Inputs/Input.stories.js
@@ -21,6 +21,7 @@ storiesOf('Input', module)
             description="This is an input with success state"
             placeholder="Placeholder"
             success={boolean('Success', true)}
+            error={boolean('Error', false)}
         />
     ))
     .add('with error', () => (


### PR DESCRIPTION
Current Implementation of LabelLayout was using a string as a truthy value and for text display. 

The use of useTransition did not result in a transition of the errorLabel when an error value was passed. 

Modified to correct usage of useTransition, added an error message prop to seperate from error.

![CEM-911-Fix-LabelLayout-Error-Display](https://user-images.githubusercontent.com/29719870/91219469-89a2fb80-e6cf-11ea-86de-da1831d8c1c9.png)
