### PR TITLE
CEM-932-Fix-TypeScript-Errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,6 +49,7 @@ module.exports = {
         'import/namespace': ['error', { allowComputed: true }],
         'import/prefer-default-export': 'off',
         'import/extensions': 'off',
+        'import/no-extraneous-dependencies': 'off',
         'no-underscore-dangle': 'off',
         'no-param-reassign': 'off',
         indent: ['error', 4],

--- a/src/Containers/Accordion/Accordion.tsx
+++ b/src/Containers/Accordion/Accordion.tsx
@@ -14,23 +14,25 @@ export const Accordion: React.FC<AccordionProps> = ({
     activeStyle = defaultActiveStyle,
     children,
     ...props
-}) => {
+}): React.ReactElement => {
     const childrenArr = Children.toArray(children);
     return (
         <div {...props}>
-            {childrenArr.map((section: React.ReactNode) => {
-                if (isValidElement(section)) {
-                    return (
-                        <AccordionItem
-                            header={section.props.header}
-                            activeStyle={activeStyle}
-                        >
-                            {section.props.children}
-                        </AccordionItem>
-                    );
-                }
-                return null;
-            })}
+            {childrenArr.map(
+                (section: React.ReactNode): React.ReactElement | null => {
+                    if (isValidElement(section)) {
+                        return (
+                            <AccordionItem
+                                header={section.props.header}
+                                activeStyle={activeStyle}
+                            >
+                                {section.props.children}
+                            </AccordionItem>
+                        );
+                    }
+                    return null;
+                },
+            )}
         </div>
     );
 };

--- a/src/Containers/Accordion/AccordionItem.tsx
+++ b/src/Containers/Accordion/AccordionItem.tsx
@@ -33,17 +33,17 @@ export const AccordionItem: React.FC<AccordionItemProps> = ({
     header,
     activeStyle,
     ...props
-}) => {
+}): React.ReactElement => {
     const [isActive, setIsActive] = useState(false);
     const [height, setHeight] = useState(0);
-    const toggleIsActive = () => {
+    const toggleIsActive = (): void => {
         setIsActive(!isActive);
     };
     const bodyRef = useRef<HTMLDivElement>(null);
     const headerRef = useRef<HTMLDivElement>(null);
     const { children } = props;
 
-    useLayoutEffect(() => {
+    useLayoutEffect((): void => {
         const bodyNode = bodyRef.current;
         const headerNode = headerRef.current;
         if (bodyNode && headerNode) {
@@ -74,7 +74,7 @@ export const AccordionItem: React.FC<AccordionItemProps> = ({
 
 const SectionDiv = styled.div<SectionDivProps>`
     overflow: hidden;
-    height: ${({ height }) => height}px;
+    height: ${({ height }): number => height}px;
     ${Mixins.transition(['height'], '0.5s')}
 `;
 
@@ -91,7 +91,7 @@ const BodyDiv = styled.div``;
 
 const Icon = styled(AngleUp)<IconProps>`
     ${transition(['transform'])}
-    transform: rotate(${({ isActive }) => (isActive ? 180 : 0)}deg);
+    transform: rotate(${({ isActive }): number => (isActive ? 180 : 0)}deg);
     width: 8px;
     float: right;
     margin-bottom: auto;

--- a/src/Containers/DiningReservation.tsx
+++ b/src/Containers/DiningReservation.tsx
@@ -5,7 +5,7 @@ import { Modal } from './Modal';
 import { Input, Datepicker, Timepicker, Button } from '..';
 
 interface DiningReservationProps {
-    modalState: any;
+    modalState: [boolean, React.Dispatch<React.SetStateAction<boolean>>];
 }
 
 export const DiningReservation: React.FC<DiningReservationProps> = ({
@@ -13,7 +13,7 @@ export const DiningReservation: React.FC<DiningReservationProps> = ({
 }): React.ReactElement => {
     return (
         <>
-            <CreateBooking onClick={() => modalState[1](true)}>
+            <CreateBooking onClick={(): void => modalState[1](true)}>
                 Create Booking
             </CreateBooking>
             <Modal state={modalState} padding="40px">

--- a/src/Containers/ImageCarousel.tsx
+++ b/src/Containers/ImageCarousel.tsx
@@ -25,7 +25,7 @@ export interface ImageCarouselProps
 
 export const ImageCarousel: React.FC<ImageCarouselProps> = ({
     imageData,
-    onClick = () => {},
+    onClick = (): void => {},
     pointer = true,
     hoverIcon = Times,
     hoverOverlay = true,
@@ -46,7 +46,8 @@ export const ImageCarousel: React.FC<ImageCarouselProps> = ({
                     >
                         {hoverOverlay && (
                             <Overlay>
-                                <Icon as={hoverIcon} /> {hoverText}
+                                <Icon as={hoverIcon} />
+                                {hoverText}
                             </Overlay>
                         )}
                         <img

--- a/src/Containers/Settings/InfoCard.tsx
+++ b/src/Containers/Settings/InfoCard.tsx
@@ -43,7 +43,9 @@ export const InfoCard: React.FC<InfoProps> = ({
     assistanceLabel = `If you require immediate assistance, please call/text: `,
 }): React.ReactElement => {
     const state = useState(false);
-    function formatPhoneNumber(companyPhoneNumberDigitString: string) {
+    function formatPhoneNumber(
+        companyPhoneNumberDigitString: string,
+    ): string | null {
         const cleaned = `${companyPhoneNumberDigitString}`.replace(/\D/g, '');
         const match = cleaned.match(/^(1|)?(\d{3})(\d{3})(\d{4})$/);
         if (match) {

--- a/src/Fragments/InputFragment.tsx
+++ b/src/Fragments/InputFragment.tsx
@@ -53,12 +53,12 @@ const InputElement = styled.input<InputFragmentProps>`
     // Background color
     ${({ theme, error = false, success = false }): string => `
         background-color: ${styledCondition(
-        error,
-        theme.colors.input.error,
-        success,
-        theme.colors.input.success,
-        theme.colors.input.default,
-    )};
+            error,
+            theme.colors.input.error,
+            success,
+            theme.colors.input.success,
+            theme.colors.input.default,
+        )};
     `}
 `;
 

--- a/src/Inputs/MaskedInput.tsx
+++ b/src/Inputs/MaskedInput.tsx
@@ -6,9 +6,9 @@ export enum MaskedInputPreset {
     PERCENTAGE = 'PERCENTAGE',
 }
 
-export interface MaskedInputProps extends LabelLayoutProps {
-    disabled?: boolean;
-    placeholder?: string;
+export interface MaskedInputProps
+    extends LabelLayoutProps,
+        React.HTMLAttributes<HTMLInputElement> {
     realValue: string;
     onRealValueChange: (value: string) => void;
     mask: MaskedInputPreset | ((value: string) => string);

--- a/src/Inputs/Switch.tsx
+++ b/src/Inputs/Switch.tsx
@@ -2,14 +2,13 @@ import React from 'react';
 import styled from 'styled-components';
 import { position, darken, flex, transition } from '../Utils/Mixins';
 
-
 export interface SwitchProps extends InputProps {
-    leftTag?:string;
-    rightTag?:string;
-    activeColor?:string;
-    switchColor?:string;
-    label?:string;
-    description?:string;
+    leftTag?: string;
+    rightTag?: string;
+    activeColor?: string;
+    switchColor?: string;
+    label?: string;
+    description?: string;
 }
 
 interface InputProps {
@@ -27,7 +26,7 @@ export const Switch: React.FC<SwitchProps> = ({
     isChecked,
     label,
     description,
-    disabled
+    disabled,
 }): React.ReactElement => (
     <Container>
         <Layout>
@@ -52,8 +51,8 @@ export const Switch: React.FC<SwitchProps> = ({
     </Container>
 );
 
-interface TagProps{
-    margin:string;
+interface TagProps {
+    margin: string;
 }
 const Tag = styled.label<TagProps>`
     margin: ${(props): string => props.margin};
@@ -104,8 +103,10 @@ const SwitchBox = styled.div<SwitchProps>`
     }
     
     ${({ switchColor }): string =>
-        switchColor ? `
-        background-color:${switchColor};` : ''}
+        switchColor
+            ? `
+        background-color:${switchColor};`
+            : ''}
 `;
 const Layout = styled.div`
     ${transition(['opacity'])}

--- a/src/Inputs/Timepicker/index.tsx
+++ b/src/Inputs/Timepicker/index.tsx
@@ -6,10 +6,12 @@ import { LabelLayout, LabelLayoutProps } from '../../Fragments';
 import { TimeDisplay } from './TimeDisplay';
 import { Timebox } from './Timebox';
 
-export interface TimepickerProps extends LabelLayoutProps {
+export interface TimepickerProps
+    extends LabelLayoutProps,
+        Omit<React.HTMLAttributes<HTMLElement>, 'onChange'> {
     value?: Date;
     period?: boolean;
-    theme: DefaultTheme;
+    theme?: DefaultTheme;
     onChange?: Function;
     disabled?: boolean;
 }
@@ -27,7 +29,7 @@ export const Timepicker: React.FC<TimepickerProps> = withTheme(
         const ref = useRef<HTMLDivElement>(null);
         const [show, setShow] = useState<boolean>();
         const [, mount, animate] = useTransition(show, {
-            end: theme.speed.normal,
+            end: theme.speed.normal || 250,
         });
 
         useEffect((): void | (() => undefined | void) => {

--- a/src/Utils/BaseStyles/Main.ts
+++ b/src/Utils/BaseStyles/Main.ts
@@ -17,10 +17,10 @@ export const Main = ({
 
     // Inline Styles
     ${
-        typeof inlineStyle === 'function'
-            ? inlineStyle({ ...props, margin, padding })
-            : inlineStyle
-    };
+    typeof inlineStyle === 'function'
+        ? inlineStyle({ ...props, margin, padding })
+        : inlineStyle
+};
 `;
 
 export const MainProps: string[] = ['margin', 'padding', 'inlineStyle'];

--- a/src/Utils/FormatDate.ts
+++ b/src/Utils/FormatDate.ts
@@ -31,17 +31,17 @@ export class FormatDate {
 
         let res = this.date.getMonth().toString();
         switch (type) {
-            case 'MM':
-                res = res.padStart(2, '0');
-                break;
-            case 'MMM':
-                res = MONTHS[res].slice(0, 3);
-                break;
-            case 'MMMM':
-                res = MONTHS[res];
-                break;
-            default:
-                break;
+        case 'MM':
+            res = res.padStart(2, '0');
+            break;
+        case 'MMM':
+            res = MONTHS[res].slice(0, 3);
+            break;
+        case 'MMMM':
+            res = MONTHS[res];
+            break;
+        default:
+            break;
         }
         this._res += prepend + res + append;
         return this;
@@ -52,17 +52,17 @@ export class FormatDate {
 
         let res = this.date.getDay().toString();
         switch (type) {
-            case 'WW':
-                res = res.padStart(2, '0');
-                break;
-            case 'WWW':
-                res = WEEKDAYS[res].slice(0, 3);
-                break;
-            case 'WWWW':
-                res = WEEKDAYS[res];
-                break;
-            default:
-                break;
+        case 'WW':
+            res = res.padStart(2, '0');
+            break;
+        case 'WWW':
+            res = WEEKDAYS[res].slice(0, 3);
+            break;
+        case 'WWWW':
+            res = WEEKDAYS[res];
+            break;
+        default:
+            break;
         }
         this._res += prepend + res + append;
         return this;
@@ -82,17 +82,17 @@ export class FormatDate {
 
         let res = this.date.getHours().toString();
         switch (type) {
-            case 'hh':
-                res = res.padStart(2, '0');
-                break;
-            case 'hp':
-                res = (parseInt(res, 10) % 12).toString();
-                break;
-            case 'hhp':
-                res = (parseInt(res, 10) % 12).toString().padStart(2, '0');
-                break;
-            default:
-                break;
+        case 'hh':
+            res = res.padStart(2, '0');
+            break;
+        case 'hp':
+            res = (parseInt(res, 10) % 12).toString();
+            break;
+        case 'hhp':
+            res = (parseInt(res, 10) % 12).toString().padStart(2, '0');
+            break;
+        default:
+            break;
         }
         this._res += prepend + res + append;
         return this;

--- a/src/Utils/Mixins/flex.ts
+++ b/src/Utils/Mixins/flex.ts
@@ -23,15 +23,15 @@ export const flex = (
         return `
             display: flex;
             ${
-                FLEX_DIRECTIONS.includes(param1)
-                    ? `
+    FLEX_DIRECTIONS.includes(param1)
+        ? `
                 flex-direction: ${param1};
             `
-                    : `
+        : `
                 justify-content: ${param1};
                 align-items: ${param1};
             `
-            }
+}
         `;
     }
 
@@ -40,17 +40,17 @@ export const flex = (
         return `
             display: flex;
             ${
-                FLEX_DIRECTIONS.includes(param1)
-                    ? `
+    FLEX_DIRECTIONS.includes(param1)
+        ? `
                 flex-direction: ${param1};
                 justify-content: ${param2};
                 align-items: ${param2};
             `
-                    : `
+        : `
                 justify-content: ${param1};
                 align-items: ${param2};
             `
-            }
+}
         `;
     }
 


### PR DESCRIPTION
There were warns in a few places about no return type on functions, fixed errors and linted. Modified eslint to not throw error for no-extraneous-dependancies which caused error to be thrown for all imports of fa-solid styled-icons.