### PR TITLE
CEM-938-Fix-TypeScript-Errors

### DIFF
--- a/src/Fragments/InputFragment.tsx
+++ b/src/Fragments/InputFragment.tsx
@@ -10,7 +10,7 @@ export interface InputFragmentProps
     disabled?: boolean;
     placeholder?: string;
     onChange?: React.ChangeEventHandler<HTMLInputElement>;
-    value?: string | number;
+    value?: string | number | string[];
     error?: boolean | string;
     success?: boolean;
     children?: React.ReactNode;

--- a/src/Inputs/MaskedInput.tsx
+++ b/src/Inputs/MaskedInput.tsx
@@ -8,7 +8,7 @@ export enum MaskedInputPreset {
 
 export interface MaskedInputProps
     extends LabelLayoutProps,
-        React.HTMLAttributes<HTMLInputElement> {
+        React.InputHTMLAttributes<HTMLInputElement> {
     realValue: string;
     onRealValueChange: (value: string) => void;
     mask: MaskedInputPreset | ((value: string) => string);


### PR DESCRIPTION
The extension of HTMLAttributes was incorrect and lead to the component not extending the property disabled. Updated input value props to accept InputHTMLAttributes<HTMLInputElement> value props and updated MaskedInput to extend InputHTMLAttributes<HTMLInputElement>.