### PR TITLE
CEM-947-Fix-Typescript-Errors-Orders-Migration

### DIFF
--- a/src/Containers/Card.tsx
+++ b/src/Containers/Card.tsx
@@ -8,7 +8,10 @@ import {
 } from '../Utils/BaseStyles';
 import { transition } from '../Utils/Mixins';
 
-export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface CardProps
+    extends MainInterface,
+        ResponsiveInterface,
+        React.HTMLAttributes<HTMLDivElement> {
     animated?: boolean;
     flat?: boolean;
 }

--- a/src/Containers/KitchenCard/KitchenCard.tsx
+++ b/src/Containers/KitchenCard/KitchenCard.tsx
@@ -20,7 +20,7 @@ export interface KitchenProps {
         name: string;
     };
     _id: string;
-    items: [Item];
+    items: Item[];
     orderType: string;
     status: string;
     index: number;

--- a/src/Containers/KitchenCard/KitchenCardItems.tsx
+++ b/src/Containers/KitchenCard/KitchenCardItems.tsx
@@ -12,7 +12,7 @@ export interface KitchenCardItemsProps
     extends MainInterface,
         ResponsiveInterface,
         React.HTMLAttributes<HTMLDivElement> {
-    items: [Item];
+    items: Item[];
     isFullName: boolean;
     modifiers: [][];
 }

--- a/src/Inputs/SettingsSwitch.tsx
+++ b/src/Inputs/SettingsSwitch.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Paragraph } from '../Text';
+import { Switch, SwitchProps } from './Switch';
+import { flex } from '../Utils/Mixins';
+
+interface SettingsSwitchProps extends SwitchProps {
+    text?: string;
+    type?: string;
+    onSwitch?: Function;
+    onSwitchValue?: any;
+    flexDirection?: string;
+    height?: string;
+    width?: string;
+    margin?: string;
+    innerMargin?: string;
+}
+
+export const SettingsSwitch: React.FC<SettingsSwitchProps> = ({
+    text,
+    type,
+    onSwitch = (): void => {},
+    onSwitchValue,
+    flexDirection,
+    height,
+    width,
+    margin,
+    innerMargin,
+    ...props
+}): React.ReactElement => {
+    const onChangeFunction = (): void => onSwitch(onSwitchValue);
+
+    return (
+        <Row
+            direction={flexDirection}
+            height={height}
+            width={width}
+            margin={margin}
+        >
+            <Paragraph size={type || 'h5'} margin={innerMargin} bold>
+                {text}
+            </Paragraph>
+            <Switch {...props} onChange={onChangeFunction} />
+        </Row>
+    );
+};
+
+interface RowProps {
+    direction?: string;
+    height?: string;
+    width?: string;
+    margin?: string;
+}
+
+const Row = styled.div<RowProps>`
+    ${(props): string => `
+         ${flex(props.direction || 'space-between')};
+         height: ${props.height};
+         width: ${props.width};
+         margin: ${props.margin};
+    `};
+`;

--- a/src/Inputs/index.ts
+++ b/src/Inputs/index.ts
@@ -17,3 +17,4 @@ export * from './MaskedInput';
 export * from './ComboBox';
 export * from './SearchBar';
 export * from './CustomSearch';
+export * from './SettingsSwitch';

--- a/stories/Inputs/SettingsSwitch.stories.js
+++ b/stories/Inputs/SettingsSwitch.stories.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withKnobs, boolean } from '@storybook/addon-knobs';
+import { SettingsSwitch} from '../../src';
+
+const switcher = (value) => console.log(value);
+
+storiesOf('SettingsSwitch', module)
+    .add('with default', () => (
+        <SettingsSwitch
+            label="Label"
+            description="Description"
+            text="Settings Switch"
+            onSwitch={switcher}
+            onSwitchValue="On Switch Value"
+        />
+    ))
+    .add('disabled flex column', () => (
+        <SettingsSwitch
+            label="Label"
+            description="Description"
+            disabled
+            flexDirection="column"
+            text="Settings Switch"
+        />
+    ))
+    .add('tags flex-end', () => (
+        <SettingsSwitch
+            leftTag="On"
+            rightTag="Off"
+            label="Label"
+            description="Description"
+            text="Settings Switch"
+            flexDirection={"flex-end"}
+            innerMargin="auto 20px auto 0"
+        />
+    ))
+    .add('activeColor center', () => (
+        <SettingsSwitch
+            leftTag="On"
+            rightTag="Off"
+            label="Label"
+            description="Description"
+            activeColor="blue"
+            text="Settings Switch"
+            flexDirection="center"
+            innerMargin="0 20px auto 0"
+        />
+    ))
+    .add('SettingsSwitchColor flex-start', () => (
+        <SettingsSwitch
+            leftTag="On"
+            rightTag="Off"
+            label="Label"
+            description="Description"
+            SettingsSwitchColor="orange"
+            text="Settings Switch"
+            flexDirection="flex-start"
+            innerMargin="auto 20px auto 0"
+        />
+    ))
+    .add('Both default', () => (
+        <SettingsSwitch
+            leftTag="On"
+            rightTag="Off"
+            label="Label"
+            description="Description"
+            SettingsSwitchColor="orange"
+            activeColor="blue"
+            text="Settings Switch"
+        />
+    ))

--- a/stories/Inputs/SettingsSwitch.stories.js
+++ b/stories/Inputs/SettingsSwitch.stories.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, boolean } from '@storybook/addon-knobs';
 import { SettingsSwitch} from '../../src';
 
 const switcher = (value) => console.log(value);


### PR DESCRIPTION
The orders migration to typescript brought up typing errors with Card since it did not extend main and responsive interfaces.

KitchenCard and KitchenCardItems were incorrectly typed as [ Item ] when it is supposed to be an array of items, Item[ ].

SettingsSwitch is a component in the terminal, adding to library.