### PR TITLE
CEM-1054 Add Functionality To List

### DIFF
--- a/src/Containers/KitchenCard/KitchenCard.tsx
+++ b/src/Containers/KitchenCard/KitchenCard.tsx
@@ -6,7 +6,7 @@ import { Status, StatusColors } from '../Status';
 import { Paragraph as P } from '../../Text';
 import { flex, media } from '../../Utils/Mixins';
 import { KitchenCardItems } from './KitchenCardItems';
-import { Item } from './constants';
+import { OrderItem } from './constants';
 
 const CUSTOMER_FIRST_NAME = /^([\w-]+)/g;
 const UNDERSCORE_FORMAT = '_';
@@ -17,12 +17,11 @@ export interface KitchenCardProps {
         name: string;
     };
     _id: string;
-    items: Item[];
+    items: OrderItem[];
     orderType: string;
     statusColor: StatusColors;
     status: string;
     index: number;
-    modifiers: [];
     isFullName?: boolean;
     cardHeight?: number;
     cardWidth: number;

--- a/src/Containers/KitchenCard/KitchenCardItems.tsx
+++ b/src/Containers/KitchenCard/KitchenCardItems.tsx
@@ -3,13 +3,17 @@ import styled from 'styled-components';
 import { Heading as H, Paragraph } from '../../Text';
 import { flex, media, scroll } from '../../Utils/Mixins';
 import { ResponsiveInterface, MainInterface } from '../../Utils/BaseStyles';
-import { Item, Choice, ModifierChoiceTypeEnum } from './constants';
+import {
+    OrderItem,
+    ModifierChoiceInput,
+    ModifierChoiceTypeEnum,
+} from './constants';
 
 export interface KitchenCardItemsProps
     extends MainInterface,
         ResponsiveInterface,
         React.HTMLAttributes<HTMLDivElement> {
-    items: Item[];
+    items: OrderItem[];
     isFullName: boolean;
 }
 
@@ -18,10 +22,10 @@ export const KitchenCardItems: React.FC<KitchenCardItemsProps> = ({
     isFullName,
 }): React.ReactElement => {
     const itemModifierRender = useCallback(
-        (item: Item) => {
+        (item: OrderItem) => {
             return item.modifiers.map((modifier) =>
                 modifier.choices.map(
-                    (choice: Choice): React.ReactElement => (
+                    (choice: ModifierChoiceInput): React.ReactElement => (
                         <Paragraph margin="5px 0 0 20px">
                             {`${
                                 choice.choice_type ===

--- a/src/Containers/KitchenCard/constants.ts
+++ b/src/Containers/KitchenCard/constants.ts
@@ -1,19 +1,17 @@
-export interface Choice{
+export interface ModifierChoiceInput {
     name: string;
     choice_type: string;
 }
-
-export interface ItemModifier {
+export interface OrderModifier {
     name?: string;
-    choices: Choice[];
+    choices: ModifierChoiceInput[];
 }
-
-export interface Item {
+export interface OrderItem {
     name: string;
-    modifiers: ItemModifier[];
+    modifiers: OrderModifier[];
 }
-export enum ModifierChoiceTypeEnum {
-    ADD = 'ADD',
-    NO = 'NO',
-    DEFAULT = 'DEFAULT'
+export declare enum ModifierChoiceTypeEnum {
+    ADD = "ADD",
+    NO = "NO",
+    DEFAULT = "DEFAULT"
 }

--- a/src/Containers/List/List.tsx
+++ b/src/Containers/List/List.tsx
@@ -3,23 +3,23 @@ import styled from 'styled-components';
 import { Mixins } from '../../Utils';
 import { Responsive, Main } from '../../Utils/BaseStyles';
 import { Loading } from '../Loading';
-import { ListToggle } from './ListToggle';
 
 export interface ListProps extends React.HTMLAttributes<HTMLDivElement> {
     loading: boolean;
     header?: React.ReactElement;
     footer?: React.ReactElement;
+    toggleComponent?: React.ReactElement;
     id: string;
     columnWidth?: string;
     margin?: string;
     right?: string;
     left?: string;
-    onToggleTranslateXAxis?: string;
+    onCloseTranslateXAxis?: string;
     cssPosition?: string;
     isToggleable?: boolean;
-    isLeftToggle?: boolean;
-    isToggled: boolean;
-    setIsToggled: React.Dispatch<React.SetStateAction<boolean>>;
+    isOpen?: boolean;
+    setIsOpen?: React.Dispatch<React.SetStateAction<boolean>>;
+    zIndex?: number;
 }
 
 export const List: React.FC<ListProps> = ({
@@ -28,24 +28,25 @@ export const List: React.FC<ListProps> = ({
     header,
     footer,
     columnWidth = '280px',
-    isToggleable,
-    isToggled,
-    setIsToggled,
-    isLeftToggle,
+    isOpen = true,
+    setIsOpen,
+    toggleComponent,
     id,
     ...props
 }): React.ReactElement => {
     useEffect((): void | (() => void | undefined) => {
         const handler = ({ type }: { type: string }): void => {
-            switch (type) {
-                case 'swipeRight':
-                    setIsToggled(true);
-                    break;
-                case 'swipeLeft':
-                    setIsToggled(false);
-                    break;
-                default:
-                    break;
+            if (setIsOpen) {
+                switch (type) {
+                    case 'swipeRight':
+                        setIsOpen(true);
+                        break;
+                    case 'swipeLeft':
+                        setIsOpen(false);
+                        break;
+                    default:
+                        break;
+                }
             }
         };
         window.addEventListener('swipeRight', handler);
@@ -57,31 +58,26 @@ export const List: React.FC<ListProps> = ({
     }, []);
 
     return (
-        <Wrapper isToggled={isToggled} {...props}>
+        <Wrapper isOpen={isOpen} {...props}>
             <Container columnWidth={columnWidth} id={id}>
                 {header}
                 <Items>{loading ? <Loading /> : children}</Items>
                 {footer}
             </Container>
-            {isToggleable && (
-                <ListToggle
-                    isToggled={isToggled}
-                    setIsToggled={setIsToggled}
-                    isLeftToggle={isLeftToggle}
-                />
-            )}
+            {toggleComponent}
         </Wrapper>
     );
 };
 
 interface WrapperProps {
-    isToggled: boolean;
+    isOpen: boolean;
     columnWidth?: string;
     margin?: string;
     right?: string;
     left?: string;
     cssPosition?: string;
-    onToggleTranslateXAxis?: string;
+    onCloseTranslateXAxis?: string;
+    zIndex?: number;
 }
 
 interface ColumnProps {
@@ -91,19 +87,20 @@ interface ColumnProps {
 const Wrapper = styled.div<WrapperProps>`
     ${Mixins.flex()}
     ${Mixins.transition(['transform'])} 
-    z-index: 99;
     height: 100%;
     ${({
-        isToggled,
-        onToggleTranslateXAxis,
+        isOpen,
+        onCloseTranslateXAxis,
         columnWidth,
         margin,
         right,
         left,
         cssPosition,
+        zIndex,
     }): string => `
-        transform: translateX(${isToggled ? onToggleTranslateXAxis : '0'});
+        transform: translateX(${isOpen ? '0' : onCloseTranslateXAxis});
         width: ${columnWidth};
+        z-index: ${zIndex};
         ${Mixins.position(cssPosition, margin, 0, right, 0, left)}        
     `}
 `;

--- a/src/Containers/List/ListHeader.tsx
+++ b/src/Containers/List/ListHeader.tsx
@@ -11,6 +11,7 @@ interface ListHeaderProps extends TextLayoutProps {
     icon?: StyledIcon;
     iconClick?: React.MouseEventHandler;
     iconProps?: string;
+    headerRowComponent?: React.ReactElement;
     type?: string;
 }
 
@@ -21,6 +22,7 @@ export const ListHeader: React.FC<ListHeaderProps> = ({
     icon,
     iconClick,
     iconProps,
+    headerRowComponent,
     ...props
 }): React.ReactElement => (
     <Header>
@@ -31,6 +33,7 @@ export const ListHeader: React.FC<ListHeaderProps> = ({
             {icon && (
                 <Icon as={icon} onClick={iconClick} iconProps={iconProps} />
             )}
+            {headerRowComponent}
         </Row>
         {children}
     </Header>

--- a/src/Containers/List/ListItem.tsx
+++ b/src/Containers/List/ListItem.tsx
@@ -1,27 +1,31 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Main } from '../../Utils/BaseStyles';
+import { Mixins } from '../../Utils';
 
 interface ListItemProps
     extends Omit<React.HTMLAttributes<HTMLLIElement>, 'onClick'> {
     onClick?: (event: React.MouseEvent<Element, MouseEvent>) => void;
     padding?: string;
-    setIsToggled?: React.Dispatch<React.SetStateAction<boolean>>;
+    setIsOpen?: React.Dispatch<React.SetStateAction<boolean>>;
+    isSelected?: boolean;
 }
 export const ListItem: React.FC<ListItemProps> = ({
     children,
     onClick,
     padding = '16px 20px',
-    setIsToggled,
+    setIsOpen,
+    isSelected,
     ...props
 }): React.ReactElement => {
     return (
         <Item
             onClick={(el): void => {
-                if (setIsToggled) setIsToggled(false);
+                if (setIsOpen) setIsOpen(false);
                 if (onClick) onClick(el);
             }}
             padding={padding}
+            isSelected={isSelected}
             {...props}
         >
             {children}
@@ -31,13 +35,21 @@ export const ListItem: React.FC<ListItemProps> = ({
 
 interface ItemProps {
     padding?: string;
+    isSelected?: boolean;
 }
 
 const Item = styled.li<ItemProps>`
-    ${({ theme }): string => `
-        border-bottom: 2px solid ${theme.colors.text}20;
-    `}
+    ${Mixins.transition(['background-color'])}
+
     ${({ padding, ...props }): string => Main({ padding, ...props })}
+    ${({ theme, isSelected }): string => `
+        border-bottom: 2px solid ${theme.colors.text}20;
+        ${
+            isSelected
+                ? `background-color: ${Mixins.darken('#ffffff', 0.1)}`
+                : Mixins.clickable('#ffffff', 0.05)
+        };
+    `}
     &:last-child {
         border-bottom: none;
     }

--- a/src/Containers/List/ListToggle.tsx
+++ b/src/Containers/List/ListToggle.tsx
@@ -8,17 +8,17 @@ const LIST_TOGGLE_RIGHT = AngleRight;
 const LIST_TOGGLE_LEFT = AngleLeft;
 
 interface ListToggleProps extends ButtonProps {
-    isToggled: boolean;
-    setIsToggled: React.Dispatch<React.SetStateAction<boolean>>;
+    isOpen: boolean;
+    setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export const ListToggle: React.FC<ListToggleProps> = ({
-    isToggled,
-    setIsToggled,
+    isOpen,
+    setIsOpen,
     isLeftToggle,
 }): React.ReactElement => {
     const toggleList = (): void => {
-        setIsToggled(!isToggled);
+        setIsOpen(!isOpen);
     };
     return (
         <Button
@@ -27,7 +27,7 @@ export const ListToggle: React.FC<ListToggleProps> = ({
             isLeftToggle={isLeftToggle}
         >
             <Icon
-                show={isToggled}
+                show={isOpen}
                 as={isLeftToggle ? LIST_TOGGLE_LEFT : LIST_TOGGLE_RIGHT}
             />
         </Button>
@@ -44,7 +44,7 @@ interface ButtonProps {
 
 const Button = styled.button<ButtonProps>`
     ${Mixins.transition(['background-color'])}
-    ${Mixins.clickable('#ffffff', 0.04)}
+    ${Mixins.clickable('#ffffff', 0.05)}
     ${({ theme, isLeftToggle }): string => `
         box-shadow: ${theme.depth[1]};
         border-radius: ${
@@ -59,6 +59,7 @@ const Button = styled.button<ButtonProps>`
             isLeftToggle ? 'auto' : '-32px',
         )}
     `}
+    z-index:-1;
     background-color: white;
     box-sizing: border-box;
     padding: 12px;
@@ -70,6 +71,6 @@ const Button = styled.button<ButtonProps>`
 
 const Icon = styled.svg<IconProps>`
     ${Mixins.transition(['transform'])}
-    transform: rotate(${({ show }): string => (show ? '180deg' : '0')});
+    transform: rotate(${({ show }): string => (show ? '0' : '180deg')});
     height: 22px;
 `;

--- a/src/Containers/Navigation.tsx
+++ b/src/Containers/Navigation.tsx
@@ -103,7 +103,12 @@ const Container = styled.nav`
         max-width: ${theme.dimensions.navigation.width}px;
         width: ${theme.dimensions.navigation.width}px;
     `}
-    ${media('tablet', 'width: auto;')}
+    ${media(
+        'tablet',
+        `
+        max-width: 70px;
+    `,
+    )}
     box-sizing: border-box;
     flex-shrink: 0;
     padding: 16px 8px 8px;

--- a/stories/Containers/List.stories.tsx
+++ b/stories/Containers/List.stories.tsx
@@ -1,6 +1,13 @@
 import React, { useState } from 'react';
 import { Cog } from '@styled-icons/fa-solid/Cog';
-import { List, ListProps, ListHeader, ListFooter, ListItem } from '../../src';
+import {
+    List,
+    ListProps,
+    ListHeader,
+    ListFooter,
+    ListItem,
+    ListToggle,
+} from '../../src';
 import { Meta, Story } from '@storybook/react';
 import { createStoryTitle } from '../Constants';
 
@@ -38,25 +45,39 @@ export default {
                 <p>This is a list Footer</p>
             </ListFooter>
         ),
+        columnWidth: '240px',
         loading: false,
         cssPosition: 'absolute',
         margin: '0',
         left: '0',
         right: 'auto',
-        onToggleTranslateXAxis: '-100%',
-        isToggleable: true,
-        isLeftToggle: true,
+        onCloseTranslateXAxis: '-100%',
         id: '1',
     },
 } as Meta;
 
 export const Basic: Story<ListProps> = (args) => {
-    const [isToggled, setIsToggled] = useState(false);
+    const [isOpen, setIsOpen] = useState(true);
 
     return (
-        <List {...args} isToggled={isToggled} setIsToggled={setIsToggled}>
+        <List
+            {...args}
+            isOpen={isOpen}
+            setIsOpen={setIsOpen}
+            toggleComponent={
+                <ListToggle
+                    isOpen={isOpen}
+                    setIsOpen={setIsOpen}
+                    isLeftToggle={true}
+                />
+            }
+        >
             {items.map((item) => (
-                <ListItem onClick={() => alert(`You clicked ${item.date}`)}>
+                <ListItem
+                    onClick={() => alert(`You clicked ${item.date}`)}
+                    setIsOpen={setIsOpen}
+                    isSelected={item.key === '2'}
+                >
                     <p>{item.date}</p>
                 </ListItem>
             ))}

--- a/stories/Containers/Stock.stories.tsx
+++ b/stories/Containers/Stock.stories.tsx
@@ -19,10 +19,10 @@ const defaultArgs = {
         { value: 10.8 },
     ],
     chartColor: 'primary',
-    title:'USER GROWTH',
-    figure:4310,
-    rate:-10,
-    bgColor:'border'
+    title: 'USER GROWTH',
+    figure: 4310,
+    rate: -10,
+    bgColor: 'border',
 };
 
 const Template: Story<StockProps> = (args) => <Stock {...args} />;


### PR DESCRIPTION
KitchenCard needed stronger typing for the data it was recieving. Added constants to KitchenCard.

List properties have been renamed for clarity, and ListToggle has been made it's own component. 

In ListHeader the option to add a component to the headerRow instead of an Icon has been added.

ListItem has a isSelected prop to indicate that an item is currently selected.

Navigation has an added media query to help with consistent styling of a collapsable list at tablet media query.


![CEM-1054-Add-Functionality-To-List](https://user-images.githubusercontent.com/29719870/95627410-07795700-0a31-11eb-832a-e4adf6d46529.gif)
