### PR TITLE
Added React.Element to LabelLayoutProps Description

### DIFF
--- a/src/Fragments/LabelLayout.tsx
+++ b/src/Fragments/LabelLayout.tsx
@@ -21,7 +21,7 @@ export interface LabelLayoutProps
         ImplicitPropsInterface {
     name?: string;
     label?: string;
-    description?: string | React.Element;
+    description?: React.ReactNode;
     error?: boolean | string;
     success?: boolean;
     className?: string;

--- a/src/Fragments/LabelLayout.tsx
+++ b/src/Fragments/LabelLayout.tsx
@@ -21,7 +21,7 @@ export interface LabelLayoutProps
         ImplicitPropsInterface {
     name?: string;
     label?: string;
-    description?: string;
+    description?: string | React.Element;
     error?: boolean | string;
     success?: boolean;
     className?: string;


### PR DESCRIPTION
LabelLayoutProps description takes in a string originally. However, some components being used in the Cheapreats Dashboard are actually React.Element. Therefore React.Element needed to be added as a type in the description. 