### PR TITLE
CEM-1162 Fix Deep Copy Typing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,7 @@ module.exports = {
         browser: true,
         node: true,
         es6: true,
+        jest: true
     },
     extends: [
         'airbnb',

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -1,0 +1,53 @@
+import deepCopy from '../src/Utils/deepCopy';
+
+test('deepCopy Number', () => {
+    const startingNumber = 2;
+    const copyNumber = deepCopy(startingNumber);
+    expect(startingNumber).toEqual(copyNumber);
+});
+
+test('deepCopy String', () => {
+    const startingString = 'test';
+    const copyString = deepCopy(startingString);
+    expect(startingString).toEqual(copyString);
+});
+
+test('deepCopy Object', () => {
+    const startingObject = { a: 'a', b: 'b' };
+    const copyObject = deepCopy(startingObject);
+    expect(startingObject).toEqual(copyObject);
+});
+
+test('deepCopy Nested Object', () => {
+    const startingObject = { a: 'a', b: 'b', c: { d: 'd', e: { f: 'f' } } };
+    const copyObject = deepCopy(startingObject);
+    expect(startingObject).toEqual(copyObject);
+});
+test('deepCopy Array', () => {
+    const startingArray = [1, 'd', 5, 'f'];
+    const copyArray = deepCopy(startingArray);
+    expect(startingArray).toEqual(copyArray);
+});
+
+test('deepCopy Nested Array', () => {
+    const startingArray = [1, 'd', 5, 'f', ['g', 4, ['f', 7]]];
+    const copyArray = deepCopy(startingArray);
+    expect(startingArray).toEqual(copyArray);
+});
+
+test('deepCopy Date', () => {
+    const startingDate = new Date();
+    const copyDate = deepCopy(startingDate);
+    expect(startingDate).toEqual(copyDate);
+});
+test('deepCopy Date Array', () => {
+    const startingDateArray = [new Date(), new Date()];
+    const copyDateArray = deepCopy(startingDateArray);
+    expect(startingDateArray).toEqual(copyDateArray);
+});
+
+test('deepCopy Date Array', () => {
+    const startingDateArray = [new Date(), new Date()];
+    const copyDateArray = deepCopy(startingDateArray);
+    expect(startingDateArray).toEqual(copyDateArray);
+});

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = {presets: ['@babel/preset-env']}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+    preset: 'ts-jest',
+    transform: {
+        '^.+\\.(ts|tsx)?$': 'ts-jest',
+        "^.+\\.(js|jsx)$": "babel-jest",
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
     "name": "@cheapreats/react-ui",
-    "version": "2.3.50",
+    "version": "2.3.51",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
         "@babel/cli": {
-            "version": "7.11.6",
-            "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.11.6.tgz",
-            "integrity": "sha512-+w7BZCvkewSmaRM6H4L2QM3RL90teqEIHDIFXAmrW33+0jhlymnDAEdqVeCZATvxhQuio1ifoGVlJJbIiH9Ffg==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.12.1.tgz",
+            "integrity": "sha512-eRJREyrfAJ2r42Iaxe8h3v6yyj1wu9OyosaUHW6UImjGf9ahGL9nsFNh7OCopvtcPL8WnEo7tp78wrZaZ6vG9g==",
             "dev": true,
             "requires": {
-                "chokidar": "^2.1.8",
+                "@nicolo-ribaudo/chokidar-2": "^2.1.8",
+                "chokidar": "^3.4.0",
                 "commander": "^4.0.1",
                 "convert-source-map": "^1.1.0",
                 "fs-readdir-recursive": "^1.1.0",
@@ -21,259 +22,17 @@
                 "source-map": "^0.5.0"
             },
             "dependencies": {
-                "anymatch": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-                    "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "micromatch": "^3.1.4",
-                        "normalize-path": "^2.1.1"
-                    },
-                    "dependencies": {
-                        "normalize-path": {
-                            "version": "2.1.1",
-                            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-                            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "remove-trailing-separator": "^1.0.1"
-                            }
-                        }
-                    }
-                },
-                "binary-extensions": {
-                    "version": "1.13.1",
-                    "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-                    "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
-                    "dev": true,
-                    "optional": true
-                },
-                "braces": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "arr-flatten": "^1.1.0",
-                        "array-unique": "^0.3.2",
-                        "extend-shallow": "^2.0.1",
-                        "fill-range": "^4.0.0",
-                        "isobject": "^3.0.1",
-                        "repeat-element": "^1.1.2",
-                        "snapdragon": "^0.8.1",
-                        "snapdragon-node": "^2.0.1",
-                        "split-string": "^3.0.2",
-                        "to-regex": "^3.0.1"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "chokidar": {
-                    "version": "2.1.8",
-                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
-                    "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "anymatch": "^2.0.0",
-                        "async-each": "^1.0.1",
-                        "braces": "^2.3.2",
-                        "fsevents": "^1.2.7",
-                        "glob-parent": "^3.1.0",
-                        "inherits": "^2.0.3",
-                        "is-binary-path": "^1.0.0",
-                        "is-glob": "^4.0.0",
-                        "normalize-path": "^3.0.0",
-                        "path-is-absolute": "^1.0.0",
-                        "readdirp": "^2.2.1",
-                        "upath": "^1.1.1"
-                    }
-                },
                 "commander": {
                     "version": "4.1.1",
                     "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
                     "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
                     "dev": true
                 },
-                "fill-range": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1",
-                        "to-regex-range": "^2.1.0"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "fsevents": {
-                    "version": "1.2.13",
-                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-                    "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "bindings": "^1.5.0",
-                        "nan": "^2.12.1"
-                    }
-                },
-                "glob-parent": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-                    "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "is-glob": "^3.1.0",
-                        "path-dirname": "^1.0.0"
-                    },
-                    "dependencies": {
-                        "is-glob": {
-                            "version": "3.1.0",
-                            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-                            "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "is-extglob": "^2.1.0"
-                            }
-                        }
-                    }
-                },
-                "is-binary-path": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-                    "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "binary-extensions": "^1.0.0"
-                    }
-                },
-                "is-extglob": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-                    "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-                    "dev": true,
-                    "optional": true
-                },
-                "is-glob": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-                    "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "is-extglob": "^2.1.1"
-                    }
-                },
-                "is-number": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
-                    }
-                },
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true,
-                    "optional": true
-                },
-                "micromatch": {
-                    "version": "3.1.10",
-                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "arr-diff": "^4.0.0",
-                        "array-unique": "^0.3.2",
-                        "braces": "^2.3.1",
-                        "define-property": "^2.0.2",
-                        "extend-shallow": "^3.0.2",
-                        "extglob": "^2.0.4",
-                        "fragment-cache": "^0.2.1",
-                        "kind-of": "^6.0.2",
-                        "nanomatch": "^1.2.9",
-                        "object.pick": "^1.3.0",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.2"
-                    }
-                },
-                "readdirp": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-                    "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.11",
-                        "micromatch": "^3.1.10",
-                        "readable-stream": "^2.0.2"
-                    }
-                },
                 "slash": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
                     "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
                     "dev": true
-                },
-                "to-regex-range": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-                    "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1"
-                    }
                 }
             }
         },
@@ -286,35 +45,23 @@
             }
         },
         "@babel/compat-data": {
-            "version": "7.11.0",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.11.0.tgz",
-            "integrity": "sha512-TPSvJfv73ng0pfnEOh17bYMPQbI95+nGWc71Ss4vZdRBHTDqmM9Z8ZV4rYz8Ks7sfzc95n30k6ODIq5UGnXcYQ==",
-            "requires": {
-                "browserslist": "^4.12.0",
-                "invariant": "^2.2.4",
-                "semver": "^5.5.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                }
-            }
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.12.1.tgz",
+            "integrity": "sha512-725AQupWJZ8ba0jbKceeFblZTY90McUBWMwHhkFQ9q1zKPJ95GUktljFcgcsIVwRnTnRKlcYzfiNImg5G9m6ZQ=="
         },
         "@babel/core": {
-            "version": "7.11.6",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
-            "integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
+            "version": "7.12.3",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.3.tgz",
+            "integrity": "sha512-0qXcZYKZp3/6N2jKYVxZv0aNCsxTSVCiK72DTiTYZAu7sjg73W0/aynWjMbiGd87EQL4WyA8reiJVh92AVla9g==",
             "requires": {
                 "@babel/code-frame": "^7.10.4",
-                "@babel/generator": "^7.11.6",
-                "@babel/helper-module-transforms": "^7.11.0",
-                "@babel/helpers": "^7.10.4",
-                "@babel/parser": "^7.11.5",
+                "@babel/generator": "^7.12.1",
+                "@babel/helper-module-transforms": "^7.12.1",
+                "@babel/helpers": "^7.12.1",
+                "@babel/parser": "^7.12.3",
                 "@babel/template": "^7.10.4",
-                "@babel/traverse": "^7.11.5",
-                "@babel/types": "^7.11.5",
+                "@babel/traverse": "^7.12.1",
+                "@babel/types": "^7.12.1",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.1",
@@ -333,11 +80,11 @@
             }
         },
         "@babel/generator": {
-            "version": "7.11.6",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
-            "integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.1.tgz",
+            "integrity": "sha512-DB+6rafIdc9o72Yc3/Ph5h+6hUjeOp66pF0naQBgUFFuPqzQwIlPTm3xZR7YNvduIMtkDIj2t21LSQwnbCrXvg==",
             "requires": {
-                "@babel/types": "^7.11.5",
+                "@babel/types": "^7.12.1",
                 "jsesc": "^2.5.1",
                 "source-map": "^0.5.0"
             }
@@ -369,24 +116,23 @@
             }
         },
         "@babel/helper-builder-react-jsx-experimental": {
-            "version": "7.11.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.11.5.tgz",
-            "integrity": "sha512-Vc4aPJnRZKWfzeCBsqTBnzulVNjABVdahSPhtdMD3Vs80ykx4a87jTHtF/VR+alSrDmNvat7l13yrRHauGcHVw==",
+            "version": "7.12.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.12.4.tgz",
+            "integrity": "sha512-AjEa0jrQqNk7eDQOo0pTfUOwQBMF+xVqrausQwT9/rTKy0g04ggFNaJpaE09IQMn9yExluigWMJcj0WC7bq+Og==",
             "requires": {
                 "@babel/helper-annotate-as-pure": "^7.10.4",
-                "@babel/helper-module-imports": "^7.10.4",
-                "@babel/types": "^7.11.5"
+                "@babel/helper-module-imports": "^7.12.1",
+                "@babel/types": "^7.12.1"
             }
         },
         "@babel/helper-compilation-targets": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.10.4.tgz",
-            "integrity": "sha512-a3rYhlsGV0UHNDvrtOXBg8/OpfV0OKTkxKPzIplS1zpx7CygDcWWxckxZeDd3gzPzC4kUT0A4nVFDK0wGMh4MQ==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.1.tgz",
+            "integrity": "sha512-jtBEif7jsPwP27GPHs06v4WBV0KrE8a/P7n0N0sSvHn2hwUCYnolP/CLmz51IzAW4NlN+HuoBtb9QcwnRo9F/g==",
             "requires": {
-                "@babel/compat-data": "^7.10.4",
+                "@babel/compat-data": "^7.12.1",
+                "@babel/helper-validator-option": "^7.12.1",
                 "browserslist": "^4.12.0",
-                "invariant": "^2.2.4",
-                "levenary": "^1.1.1",
                 "semver": "^5.5.0"
             },
             "dependencies": {
@@ -398,26 +144,25 @@
             }
         },
         "@babel/helper-create-class-features-plugin": {
-            "version": "7.10.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.5.tgz",
-            "integrity": "sha512-0nkdeijB7VlZoLT3r/mY3bUkw3T8WG/hNw+FATs/6+pG2039IJWjTYL0VTISqsNHMUTEnwbVnc89WIJX9Qed0A==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.1.tgz",
+            "integrity": "sha512-hkL++rWeta/OVOBTRJc9a5Azh5mt5WgZUGAKMD8JM141YsE08K//bp1unBBieO6rUKkIPyUE0USQ30jAy3Sk1w==",
             "requires": {
                 "@babel/helper-function-name": "^7.10.4",
-                "@babel/helper-member-expression-to-functions": "^7.10.5",
+                "@babel/helper-member-expression-to-functions": "^7.12.1",
                 "@babel/helper-optimise-call-expression": "^7.10.4",
-                "@babel/helper-plugin-utils": "^7.10.4",
-                "@babel/helper-replace-supers": "^7.10.4",
+                "@babel/helper-replace-supers": "^7.12.1",
                 "@babel/helper-split-export-declaration": "^7.10.4"
             }
         },
         "@babel/helper-create-regexp-features-plugin": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.10.4.tgz",
-            "integrity": "sha512-2/hu58IEPKeoLF45DBwx3XFqsbCXmkdAay4spVr2x0jYgRxrSNp+ePwvSsy9g6YSaNDcKIQVPXk1Ov8S2edk2g==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.1.tgz",
+            "integrity": "sha512-rsZ4LGvFTZnzdNZR5HZdmJVuXK8834R5QkF3WvcnBhrlVtF0HSIUC6zbreL9MgjTywhKokn8RIYRiq99+DLAxA==",
             "requires": {
                 "@babel/helper-annotate-as-pure": "^7.10.4",
                 "@babel/helper-regex": "^7.10.4",
-                "regexpu-core": "^4.7.0"
+                "regexpu-core": "^4.7.1"
             }
         },
         "@babel/helper-define-map": {
@@ -431,11 +176,11 @@
             }
         },
         "@babel/helper-explode-assignable-expression": {
-            "version": "7.11.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.11.4.tgz",
-            "integrity": "sha512-ux9hm3zR4WV1Y3xXxXkdG/0gxF9nvI0YVmKVhvK9AfMoaQkemL3sJpXw+Xbz65azo8qJiEz2XVDUpK3KYhH3ZQ==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.12.1.tgz",
+            "integrity": "sha512-dmUwH8XmlrUpVqgtZ737tK88v07l840z9j3OEhCLwKTkjlvKpfqXVIZ0wpK3aeOxspwGrf/5AP5qLx4rO3w5rA==",
             "requires": {
-                "@babel/types": "^7.10.4"
+                "@babel/types": "^7.12.1"
             }
         },
         "@babel/helper-function-name": {
@@ -465,32 +210,34 @@
             }
         },
         "@babel/helper-member-expression-to-functions": {
-            "version": "7.11.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
-            "integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
+            "integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
             "requires": {
-                "@babel/types": "^7.11.0"
+                "@babel/types": "^7.12.1"
             }
         },
         "@babel/helper-module-imports": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
-            "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.1.tgz",
+            "integrity": "sha512-ZeC1TlMSvikvJNy1v/wPIazCu3NdOwgYZLIkmIyAsGhqkNpiDoQQRmaCK8YP4Pq3GPTLPV9WXaPCJKvx06JxKA==",
             "requires": {
-                "@babel/types": "^7.10.4"
+                "@babel/types": "^7.12.1"
             }
         },
         "@babel/helper-module-transforms": {
-            "version": "7.11.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
-            "integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
+            "integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
             "requires": {
-                "@babel/helper-module-imports": "^7.10.4",
-                "@babel/helper-replace-supers": "^7.10.4",
-                "@babel/helper-simple-access": "^7.10.4",
+                "@babel/helper-module-imports": "^7.12.1",
+                "@babel/helper-replace-supers": "^7.12.1",
+                "@babel/helper-simple-access": "^7.12.1",
                 "@babel/helper-split-export-declaration": "^7.11.0",
+                "@babel/helper-validator-identifier": "^7.10.4",
                 "@babel/template": "^7.10.4",
-                "@babel/types": "^7.11.0",
+                "@babel/traverse": "^7.12.1",
+                "@babel/types": "^7.12.1",
                 "lodash": "^4.17.19"
             }
         },
@@ -516,42 +263,40 @@
             }
         },
         "@babel/helper-remap-async-to-generator": {
-            "version": "7.11.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.11.4.tgz",
-            "integrity": "sha512-tR5vJ/vBa9wFy3m5LLv2faapJLnDFxNWff2SAYkSE4rLUdbp7CdObYFgI7wK4T/Mj4UzpjPwzR8Pzmr5m7MHGA==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.12.1.tgz",
+            "integrity": "sha512-9d0KQCRM8clMPcDwo8SevNs+/9a8yWVVmaE80FGJcEP8N1qToREmWEGnBn8BUlJhYRFz6fqxeRL1sl5Ogsed7A==",
             "requires": {
                 "@babel/helper-annotate-as-pure": "^7.10.4",
                 "@babel/helper-wrap-function": "^7.10.4",
-                "@babel/template": "^7.10.4",
-                "@babel/types": "^7.10.4"
+                "@babel/types": "^7.12.1"
             }
         },
         "@babel/helper-replace-supers": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-            "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.1.tgz",
+            "integrity": "sha512-zJjTvtNJnCFsCXVi5rUInstLd/EIVNmIKA1Q9ynESmMBWPWd+7sdR+G4/wdu+Mppfep0XLyG2m7EBPvjCeFyrw==",
             "requires": {
-                "@babel/helper-member-expression-to-functions": "^7.10.4",
+                "@babel/helper-member-expression-to-functions": "^7.12.1",
                 "@babel/helper-optimise-call-expression": "^7.10.4",
-                "@babel/traverse": "^7.10.4",
-                "@babel/types": "^7.10.4"
+                "@babel/traverse": "^7.12.1",
+                "@babel/types": "^7.12.1"
             }
         },
         "@babel/helper-simple-access": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
-            "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
+            "integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
             "requires": {
-                "@babel/template": "^7.10.4",
-                "@babel/types": "^7.10.4"
+                "@babel/types": "^7.12.1"
             }
         },
         "@babel/helper-skip-transparent-expression-wrappers": {
-            "version": "7.11.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.11.0.tgz",
-            "integrity": "sha512-0XIdiQln4Elglgjbwo9wuJpL/K7AGCY26kmEt0+pRP0TAj4jjyNq1MjoRvikrTVqKcx4Gysxt4cXvVFXP/JO2Q==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.12.1.tgz",
+            "integrity": "sha512-Mf5AUuhG1/OCChOJ/HcADmvcHM42WJockombn8ATJG3OnyiSxBK/Mm5x78BQWvmtXZKHgbjdGL2kin/HOLlZGA==",
             "requires": {
-                "@babel/types": "^7.11.0"
+                "@babel/types": "^7.12.1"
             }
         },
         "@babel/helper-split-export-declaration": {
@@ -567,10 +312,15 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
             "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
         },
+        "@babel/helper-validator-option": {
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.1.tgz",
+            "integrity": "sha512-YpJabsXlJVWP0USHjnC/AQDTLlZERbON577YUVO/wLpqyj6HAtVYnWaQaN0iUN+1/tWn3c+uKKXjRut5115Y2A=="
+        },
         "@babel/helper-wrap-function": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.10.4.tgz",
-            "integrity": "sha512-6py45WvEF0MhiLrdxtRjKjufwLL1/ob2qDJgg5JgNdojBAZSAKnAjkyOCNug6n+OBl4VW76XjvgSFTdaMcW0Ug==",
+            "version": "7.12.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.12.3.tgz",
+            "integrity": "sha512-Cvb8IuJDln3rs6tzjW3Y8UeelAOdnpB8xtQ4sme2MSZ9wOxrbThporC0y/EtE16VAtoyEfLM404Xr1e0OOp+ow==",
             "requires": {
                 "@babel/helper-function-name": "^7.10.4",
                 "@babel/template": "^7.10.4",
@@ -579,13 +329,13 @@
             }
         },
         "@babel/helpers": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
-            "integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.1.tgz",
+            "integrity": "sha512-9JoDSBGoWtmbay98efmT2+mySkwjzeFeAL9BuWNoVQpkPFQF8SIIFUfY5os9u8wVzglzoiPRSW7cuJmBDUt43g==",
             "requires": {
                 "@babel/template": "^7.10.4",
-                "@babel/traverse": "^7.10.4",
-                "@babel/types": "^7.10.4"
+                "@babel/traverse": "^7.12.1",
+                "@babel/types": "^7.12.1"
             }
         },
         "@babel/highlight": {
@@ -599,146 +349,146 @@
             }
         },
         "@babel/parser": {
-            "version": "7.11.5",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
-            "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q=="
+            "version": "7.12.3",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.3.tgz",
+            "integrity": "sha512-kFsOS0IbsuhO5ojF8Hc8z/8vEIOkylVBrjiZUbLTE3XFe0Qi+uu6HjzQixkFaqr0ZPAMZcBVxEwmsnsLPZ2Xsw=="
         },
         "@babel/plugin-proposal-async-generator-functions": {
-            "version": "7.10.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.5.tgz",
-            "integrity": "sha512-cNMCVezQbrRGvXJwm9fu/1sJj9bHdGAgKodZdLqOQIpfoH3raqmRPBM17+lh7CzhiKRRBrGtZL9WcjxSoGYUSg==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.12.1.tgz",
+            "integrity": "sha512-d+/o30tJxFxrA1lhzJqiUcEJdI6jKlNregCv5bASeGf2Q4MXmnwH7viDo7nhx1/ohf09oaH8j1GVYG/e3Yqk6A==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4",
-                "@babel/helper-remap-async-to-generator": "^7.10.4",
+                "@babel/helper-remap-async-to-generator": "^7.12.1",
                 "@babel/plugin-syntax-async-generators": "^7.8.0"
             }
         },
         "@babel/plugin-proposal-class-properties": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.10.4.tgz",
-            "integrity": "sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.12.1.tgz",
+            "integrity": "sha512-cKp3dlQsFsEs5CWKnN7BnSHOd0EOW8EKpEjkoz1pO2E5KzIDNV9Ros1b0CnmbVgAGXJubOYVBOGCT1OmJwOI7w==",
             "requires": {
-                "@babel/helper-create-class-features-plugin": "^7.10.4",
+                "@babel/helper-create-class-features-plugin": "^7.12.1",
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-proposal-decorators": {
-            "version": "7.10.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.10.5.tgz",
-            "integrity": "sha512-Sc5TAQSZuLzgY0664mMDn24Vw2P8g/VhyLyGPaWiHahhgLqeZvcGeyBZOrJW0oSKIK2mvQ22a1ENXBIQLhrEiQ==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.12.1.tgz",
+            "integrity": "sha512-knNIuusychgYN8fGJHONL0RbFxLGawhXOJNLBk75TniTsZZeA+wdkDuv6wp4lGwzQEKjZi6/WYtnb3udNPmQmQ==",
             "requires": {
-                "@babel/helper-create-class-features-plugin": "^7.10.5",
+                "@babel/helper-create-class-features-plugin": "^7.12.1",
                 "@babel/helper-plugin-utils": "^7.10.4",
-                "@babel/plugin-syntax-decorators": "^7.10.4"
+                "@babel/plugin-syntax-decorators": "^7.12.1"
             }
         },
         "@babel/plugin-proposal-dynamic-import": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.10.4.tgz",
-            "integrity": "sha512-up6oID1LeidOOASNXgv/CFbgBqTuKJ0cJjz6An5tWD+NVBNlp3VNSBxv2ZdU7SYl3NxJC7agAQDApZusV6uFwQ==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.12.1.tgz",
+            "integrity": "sha512-a4rhUSZFuq5W8/OO8H7BL5zspjnc1FLd9hlOxIK/f7qG4a0qsqk8uvF/ywgBA8/OmjsapjpvaEOYItfGG1qIvQ==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4",
                 "@babel/plugin-syntax-dynamic-import": "^7.8.0"
             }
         },
         "@babel/plugin-proposal-export-default-from": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.10.4.tgz",
-            "integrity": "sha512-G1l00VvDZ7Yk2yRlC5D8Ybvu3gmeHS3rCHoUYdjrqGYUtdeOBoRypnvDZ5KQqxyaiiGHWnVDeSEzA5F9ozItig==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.12.1.tgz",
+            "integrity": "sha512-z5Q4Ke7j0AexQRfgUvnD+BdCSgpTEKnqQ3kskk2jWtOBulxICzd1X9BGt7kmWftxZ2W3++OZdt5gtmC8KLxdRQ==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4",
-                "@babel/plugin-syntax-export-default-from": "^7.10.4"
+                "@babel/plugin-syntax-export-default-from": "^7.12.1"
             }
         },
         "@babel/plugin-proposal-export-namespace-from": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.10.4.tgz",
-            "integrity": "sha512-aNdf0LY6/3WXkhh0Fdb6Zk9j1NMD8ovj3F6r0+3j837Pn1S1PdNtcwJ5EG9WkVPNHPxyJDaxMaAOVq4eki0qbg==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.12.1.tgz",
+            "integrity": "sha512-6CThGf0irEkzujYS5LQcjBx8j/4aQGiVv7J9+2f7pGfxqyKh3WnmVJYW3hdrQjyksErMGBPQrCnHfOtna+WLbw==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4",
                 "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
             }
         },
         "@babel/plugin-proposal-json-strings": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.10.4.tgz",
-            "integrity": "sha512-fCL7QF0Jo83uy1K0P2YXrfX11tj3lkpN7l4dMv9Y9VkowkhkQDwFHFd8IiwyK5MZjE8UpbgokkgtcReH88Abaw==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.12.1.tgz",
+            "integrity": "sha512-GoLDUi6U9ZLzlSda2Df++VSqDJg3CG+dR0+iWsv6XRw1rEq+zwt4DirM9yrxW6XWaTpmai1cWJLMfM8qQJf+yw==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4",
                 "@babel/plugin-syntax-json-strings": "^7.8.0"
             }
         },
         "@babel/plugin-proposal-logical-assignment-operators": {
-            "version": "7.11.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.11.0.tgz",
-            "integrity": "sha512-/f8p4z+Auz0Uaf+i8Ekf1iM7wUNLcViFUGiPxKeXvxTSl63B875YPiVdUDdem7hREcI0E0kSpEhS8tF5RphK7Q==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.12.1.tgz",
+            "integrity": "sha512-k8ZmVv0JU+4gcUGeCDZOGd0lCIamU/sMtIiX3UWnUc5yzgq6YUGyEolNYD+MLYKfSzgECPcqetVcJP9Afe/aCA==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4",
                 "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
             }
         },
         "@babel/plugin-proposal-nullish-coalescing-operator": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.10.4.tgz",
-            "integrity": "sha512-wq5n1M3ZUlHl9sqT2ok1T2/MTt6AXE0e1Lz4WzWBr95LsAZ5qDXe4KnFuauYyEyLiohvXFMdbsOTMyLZs91Zlw==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.12.1.tgz",
+            "integrity": "sha512-nZY0ESiaQDI1y96+jk6VxMOaL4LPo/QDHBqL+SF3/vl6dHkTwHlOI8L4ZwuRBHgakRBw5zsVylel7QPbbGuYgg==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4",
                 "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
             }
         },
         "@babel/plugin-proposal-numeric-separator": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.10.4.tgz",
-            "integrity": "sha512-73/G7QoRoeNkLZFxsoCCvlg4ezE4eM+57PnOqgaPOozd5myfj7p0muD1mRVJvbUWbOzD+q3No2bWbaKy+DJ8DA==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.1.tgz",
+            "integrity": "sha512-MR7Ok+Af3OhNTCxYVjJZHS0t97ydnJZt/DbR4WISO39iDnhiD8XHrY12xuSJ90FFEGjir0Fzyyn7g/zY6hxbxA==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4",
                 "@babel/plugin-syntax-numeric-separator": "^7.10.4"
             }
         },
         "@babel/plugin-proposal-object-rest-spread": {
-            "version": "7.11.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.11.0.tgz",
-            "integrity": "sha512-wzch41N4yztwoRw0ak+37wxwJM2oiIiy6huGCoqkvSTA9acYWcPfn9Y4aJqmFFJ70KTJUu29f3DQ43uJ9HXzEA==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.12.1.tgz",
+            "integrity": "sha512-s6SowJIjzlhx8o7lsFx5zmY4At6CTtDvgNQDdPzkBQucle58A6b/TTeEBYtyDgmcXjUTM+vE8YOGHZzzbc/ioA==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4",
                 "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-                "@babel/plugin-transform-parameters": "^7.10.4"
+                "@babel/plugin-transform-parameters": "^7.12.1"
             }
         },
         "@babel/plugin-proposal-optional-catch-binding": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.10.4.tgz",
-            "integrity": "sha512-LflT6nPh+GK2MnFiKDyLiqSqVHkQnVf7hdoAvyTnnKj9xB3docGRsdPuxp6qqqW19ifK3xgc9U5/FwrSaCNX5g==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.12.1.tgz",
+            "integrity": "sha512-hFvIjgprh9mMw5v42sJWLI1lzU5L2sznP805zeT6rySVRA0Y18StRhDqhSxlap0oVgItRsB6WSROp4YnJTJz0g==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4",
                 "@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
             }
         },
         "@babel/plugin-proposal-optional-chaining": {
-            "version": "7.11.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.11.0.tgz",
-            "integrity": "sha512-v9fZIu3Y8562RRwhm1BbMRxtqZNFmFA2EG+pT2diuU8PT3H6T/KXoZ54KgYisfOFZHV6PfvAiBIZ9Rcz+/JCxA==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.1.tgz",
+            "integrity": "sha512-c2uRpY6WzaVDzynVY9liyykS+kVU+WRZPMPYpkelXH8KBt1oXoI89kPbZKKG/jDT5UK92FTW2fZkZaJhdiBabw==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.11.0",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.12.1",
                 "@babel/plugin-syntax-optional-chaining": "^7.8.0"
             }
         },
         "@babel/plugin-proposal-private-methods": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.10.4.tgz",
-            "integrity": "sha512-wh5GJleuI8k3emgTg5KkJK6kHNsGEr0uBTDBuQUBJwckk9xs1ez79ioheEVVxMLyPscB0LfkbVHslQqIzWV6Bw==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.12.1.tgz",
+            "integrity": "sha512-mwZ1phvH7/NHK6Kf8LP7MYDogGV+DKB1mryFOEwx5EBNQrosvIczzZFTUmWaeujd5xT6G1ELYWUz3CutMhjE1w==",
             "requires": {
-                "@babel/helper-create-class-features-plugin": "^7.10.4",
+                "@babel/helper-create-class-features-plugin": "^7.12.1",
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-proposal-unicode-property-regex": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.10.4.tgz",
-            "integrity": "sha512-H+3fOgPnEXFL9zGYtKQe4IDOPKYlZdF1kqFDQRRb8PK4B8af1vAGK04tF5iQAAsui+mHNBQSAtd2/ndEDe9wuA==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.12.1.tgz",
+            "integrity": "sha512-MYq+l+PvHuw/rKUz1at/vb6nCnQ2gmJBNaM62z0OgH7B2W1D9pvkpYtlti9bGtizNIU1K3zm4bZF9F91efVY0w==",
             "requires": {
-                "@babel/helper-create-regexp-features-plugin": "^7.10.4",
+                "@babel/helper-create-regexp-features-plugin": "^7.12.1",
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
@@ -750,18 +500,27 @@
                 "@babel/helper-plugin-utils": "^7.8.0"
             }
         },
+        "@babel/plugin-syntax-bigint": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+            "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
         "@babel/plugin-syntax-class-properties": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz",
-            "integrity": "sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.1.tgz",
+            "integrity": "sha512-U40A76x5gTwmESz+qiqssqmeEsKvcSyvtgktrm0uzcARAmM9I1jR221f6Oq+GmHrcD+LvZDag1UTOTe2fL3TeA==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-syntax-decorators": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.10.4.tgz",
-            "integrity": "sha512-2NaoC6fAk2VMdhY1eerkfHV+lVYC1u8b+jmRJISqANCJlTxYy19HGdIkkQtix2UtkcPuPu+IlDgrVseZnU03bw==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.12.1.tgz",
+            "integrity": "sha512-ir9YW5daRrTYiy9UJ2TzdNIJEZu8KclVzDcfSt4iEmOtwQ4llPtWInNKJyKnVXp1vE4bbVd5S31M/im3mYMO1w==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
@@ -775,9 +534,9 @@
             }
         },
         "@babel/plugin-syntax-export-default-from": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.10.4.tgz",
-            "integrity": "sha512-79V6r6Pgudz0RnuMGp5xidu6Z+bPFugh8/Q9eDHonmLp4wKFAZDwygJwYgCzuDu8lFA/sYyT+mc5y2wkd7bTXA==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.12.1.tgz",
+            "integrity": "sha512-dP5eGg6tHEkhnRD2/vRG/KJKRSg8gtxu2i+P/8/yFPJn/CfPU5G0/7Gks2i3M6IOVAPQekmsLN9LPsmXFFL4Uw==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
@@ -791,9 +550,18 @@
             }
         },
         "@babel/plugin-syntax-flow": {
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.12.1.tgz",
+            "integrity": "sha512-1lBLLmtxrwpm4VKmtVFselI/P3pX+G63fAtUUt6b2Nzgao77KNDwyuRt90Mj2/9pKobtt68FdvjfqohZjg/FCA==",
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-syntax-import-meta": {
             "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.10.4.tgz",
-            "integrity": "sha512-yxQsX1dJixF4qEEdzVbst3SZQ58Nrooz8NV9Z9GL4byTE25BvJgl5lf0RECUf0fh28rZBb/RYTWn/eeKwCMrZQ==",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+            "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
@@ -807,9 +575,9 @@
             }
         },
         "@babel/plugin-syntax-jsx": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.10.4.tgz",
-            "integrity": "sha512-KCg9mio9jwiARCB7WAcQ7Y1q+qicILjoK8LP/VkPkEKaf5dkaZZK1EcTe91a3JJlZ3qy6L5s9X52boEYi8DM9g==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.12.1.tgz",
+            "integrity": "sha512-1yRi7yAtB0ETgxdY9ti/p2TivUxJkTdhu/ZbF9MshVGqOx1TdB3b7xCXs49Fupgg50N45KcAsRP/ZqWjs9SRjg==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
@@ -863,411 +631,409 @@
             }
         },
         "@babel/plugin-syntax-top-level-await": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.10.4.tgz",
-            "integrity": "sha512-ni1brg4lXEmWyafKr0ccFWkJG0CeMt4WV1oyeBW6EFObF4oOHclbkj5cARxAPQyAQ2UTuplJyK4nfkXIMMFvsQ==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.1.tgz",
+            "integrity": "sha512-i7ooMZFS+a/Om0crxZodrTzNEPJHZrlMVGMTEpFAj6rYY/bKCddB0Dk/YxfPuYXOopuhKk/e1jV6h+WUU9XN3A==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-syntax-typescript": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.10.4.tgz",
-            "integrity": "sha512-oSAEz1YkBCAKr5Yiq8/BNtvSAPwkp/IyUnwZogd8p+F0RuYQQrLeRUzIQhueQTTBy/F+a40uS7OFKxnkRvmvFQ==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.12.1.tgz",
+            "integrity": "sha512-UZNEcCY+4Dp9yYRCAHrHDU+9ZXLYaY9MgBXSRLkB9WjYFRR6quJBumfVrEkUxrePPBwFcpWfNKXqVRQQtm7mMA==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-arrow-functions": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.10.4.tgz",
-            "integrity": "sha512-9J/oD1jV0ZCBcgnoFWFq1vJd4msoKb/TCpGNFyyLt0zABdcvgK3aYikZ8HjzB14c26bc7E3Q1yugpwGy2aTPNA==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.12.1.tgz",
+            "integrity": "sha512-5QB50qyN44fzzz4/qxDPQMBCTHgxg3n0xRBLJUmBlLoU/sFvxVWGZF/ZUfMVDQuJUKXaBhbupxIzIfZ6Fwk/0A==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-async-to-generator": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.10.4.tgz",
-            "integrity": "sha512-F6nREOan7J5UXTLsDsZG3DXmZSVofr2tGNwfdrVwkDWHfQckbQXnXSPfD7iO+c/2HGqycwyLST3DnZ16n+cBJQ==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.12.1.tgz",
+            "integrity": "sha512-SDtqoEcarK1DFlRJ1hHRY5HvJUj5kX4qmtpMAm2QnhOlyuMC4TMdCRgW6WXpv93rZeYNeLP22y8Aq2dbcDRM1A==",
             "requires": {
-                "@babel/helper-module-imports": "^7.10.4",
+                "@babel/helper-module-imports": "^7.12.1",
                 "@babel/helper-plugin-utils": "^7.10.4",
-                "@babel/helper-remap-async-to-generator": "^7.10.4"
+                "@babel/helper-remap-async-to-generator": "^7.12.1"
             }
         },
         "@babel/plugin-transform-block-scoped-functions": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.10.4.tgz",
-            "integrity": "sha512-WzXDarQXYYfjaV1szJvN3AD7rZgZzC1JtjJZ8dMHUyiK8mxPRahynp14zzNjU3VkPqPsO38CzxiWO1c9ARZ8JA==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.12.1.tgz",
+            "integrity": "sha512-5OpxfuYnSgPalRpo8EWGPzIYf0lHBWORCkj5M0oLBwHdlux9Ri36QqGW3/LR13RSVOAoUUMzoPI/jpE4ABcHoA==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-block-scoping": {
-            "version": "7.11.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.11.1.tgz",
-            "integrity": "sha512-00dYeDE0EVEHuuM+26+0w/SCL0BH2Qy7LwHuI4Hi4MH5gkC8/AqMN5uWFJIsoXZrAphiMm1iXzBw6L2T+eA0ew==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.1.tgz",
+            "integrity": "sha512-zJyAC9sZdE60r1nVQHblcfCj29Dh2Y0DOvlMkcqSo0ckqjiCwNiUezUKw+RjOCwGfpLRwnAeQ2XlLpsnGkvv9w==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-classes": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.10.4.tgz",
-            "integrity": "sha512-2oZ9qLjt161dn1ZE0Ms66xBncQH4In8Sqw1YWgBUZuGVJJS5c0OFZXL6dP2MRHrkU/eKhWg8CzFJhRQl50rQxA==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.12.1.tgz",
+            "integrity": "sha512-/74xkA7bVdzQTBeSUhLLJgYIcxw/dpEpCdRDiHgPJ3Mv6uC11UhjpOhl72CgqbBCmt1qtssCyB2xnJm1+PFjog==",
             "requires": {
                 "@babel/helper-annotate-as-pure": "^7.10.4",
                 "@babel/helper-define-map": "^7.10.4",
                 "@babel/helper-function-name": "^7.10.4",
                 "@babel/helper-optimise-call-expression": "^7.10.4",
                 "@babel/helper-plugin-utils": "^7.10.4",
-                "@babel/helper-replace-supers": "^7.10.4",
+                "@babel/helper-replace-supers": "^7.12.1",
                 "@babel/helper-split-export-declaration": "^7.10.4",
                 "globals": "^11.1.0"
             }
         },
         "@babel/plugin-transform-computed-properties": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.10.4.tgz",
-            "integrity": "sha512-JFwVDXcP/hM/TbyzGq3l/XWGut7p46Z3QvqFMXTfk6/09m7xZHJUN9xHfsv7vqqD4YnfI5ueYdSJtXqqBLyjBw==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.12.1.tgz",
+            "integrity": "sha512-vVUOYpPWB7BkgUWPo4C44mUQHpTZXakEqFjbv8rQMg7TC6S6ZhGZ3otQcRH6u7+adSlE5i0sp63eMC/XGffrzg==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-destructuring": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.4.tgz",
-            "integrity": "sha512-+WmfvyfsyF603iPa6825mq6Qrb7uLjTOsa3XOFzlYcYDHSS4QmpOWOL0NNBY5qMbvrcf3tq0Cw+v4lxswOBpgA==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.12.1.tgz",
+            "integrity": "sha512-fRMYFKuzi/rSiYb2uRLiUENJOKq4Gnl+6qOv5f8z0TZXg3llUwUhsNNwrwaT/6dUhJTzNpBr+CUvEWBtfNY1cw==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-dotall-regex": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.10.4.tgz",
-            "integrity": "sha512-ZEAVvUTCMlMFAbASYSVQoxIbHm2OkG2MseW6bV2JjIygOjdVv8tuxrCTzj1+Rynh7ODb8GivUy7dzEXzEhuPaA==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.12.1.tgz",
+            "integrity": "sha512-B2pXeRKoLszfEW7J4Hg9LoFaWEbr/kzo3teWHmtFCszjRNa/b40f9mfeqZsIDLLt/FjwQ6pz/Gdlwy85xNckBA==",
             "requires": {
-                "@babel/helper-create-regexp-features-plugin": "^7.10.4",
+                "@babel/helper-create-regexp-features-plugin": "^7.12.1",
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-duplicate-keys": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.10.4.tgz",
-            "integrity": "sha512-GL0/fJnmgMclHiBTTWXNlYjYsA7rDrtsazHG6mglaGSTh0KsrW04qml+Bbz9FL0LcJIRwBWL5ZqlNHKTkU3xAA==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.12.1.tgz",
+            "integrity": "sha512-iRght0T0HztAb/CazveUpUQrZY+aGKKaWXMJ4uf9YJtqxSUe09j3wteztCUDRHs+SRAL7yMuFqUsLoAKKzgXjw==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-exponentiation-operator": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.10.4.tgz",
-            "integrity": "sha512-S5HgLVgkBcRdyQAHbKj+7KyuWx8C6t5oETmUuwz1pt3WTWJhsUV0WIIXuVvfXMxl/QQyHKlSCNNtaIamG8fysw==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.12.1.tgz",
+            "integrity": "sha512-7tqwy2bv48q+c1EHbXK0Zx3KXd2RVQp6OC7PbwFNt/dPTAV3Lu5sWtWuAj8owr5wqtWnqHfl2/mJlUmqkChKug==",
             "requires": {
                 "@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.4",
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-flow-strip-types": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.10.4.tgz",
-            "integrity": "sha512-XTadyuqNst88UWBTdLjM+wEY7BFnY2sYtPyAidfC7M/QaZnSuIZpMvLxqGT7phAcnGyWh/XQFLKcGf04CnvxSQ==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.12.1.tgz",
+            "integrity": "sha512-8hAtkmsQb36yMmEtk2JZ9JnVyDSnDOdlB+0nEGzIDLuK4yR3JcEjfuFPYkdEPSh8Id+rAMeBEn+X0iVEyho6Hg==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4",
-                "@babel/plugin-syntax-flow": "^7.10.4"
+                "@babel/plugin-syntax-flow": "^7.12.1"
             }
         },
         "@babel/plugin-transform-for-of": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.10.4.tgz",
-            "integrity": "sha512-ItdQfAzu9AlEqmusA/65TqJ79eRcgGmpPPFvBnGILXZH975G0LNjP1yjHvGgfuCxqrPPueXOPe+FsvxmxKiHHQ==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.12.1.tgz",
+            "integrity": "sha512-Zaeq10naAsuHo7heQvyV0ptj4dlZJwZgNAtBYBnu5nNKJoW62m0zKcIEyVECrUKErkUkg6ajMy4ZfnVZciSBhg==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-function-name": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.10.4.tgz",
-            "integrity": "sha512-OcDCq2y5+E0dVD5MagT5X+yTRbcvFjDI2ZVAottGH6tzqjx/LKpgkUepu3hp/u4tZBzxxpNGwLsAvGBvQ2mJzg==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.12.1.tgz",
+            "integrity": "sha512-JF3UgJUILoFrFMEnOJLJkRHSk6LUSXLmEFsA23aR2O5CSLUxbeUX1IZ1YQ7Sn0aXb601Ncwjx73a+FVqgcljVw==",
             "requires": {
                 "@babel/helper-function-name": "^7.10.4",
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-literals": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.10.4.tgz",
-            "integrity": "sha512-Xd/dFSTEVuUWnyZiMu76/InZxLTYilOSr1UlHV+p115Z/Le2Fi1KXkJUYz0b42DfndostYlPub3m8ZTQlMaiqQ==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.12.1.tgz",
+            "integrity": "sha512-+PxVGA+2Ag6uGgL0A5f+9rklOnnMccwEBzwYFL3EUaKuiyVnUipyXncFcfjSkbimLrODoqki1U9XxZzTvfN7IQ==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-member-expression-literals": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.10.4.tgz",
-            "integrity": "sha512-0bFOvPyAoTBhtcJLr9VcwZqKmSjFml1iVxvPL0ReomGU53CX53HsM4h2SzckNdkQcHox1bpAqzxBI1Y09LlBSw==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.12.1.tgz",
+            "integrity": "sha512-1sxePl6z9ad0gFMB9KqmYofk34flq62aqMt9NqliS/7hPEpURUCMbyHXrMPlo282iY7nAvUB1aQd5mg79UD9Jg==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-modules-amd": {
-            "version": "7.10.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.10.5.tgz",
-            "integrity": "sha512-elm5uruNio7CTLFItVC/rIzKLfQ17+fX7EVz5W0TMgIHFo1zY0Ozzx+lgwhL4plzl8OzVn6Qasx5DeEFyoNiRw==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.12.1.tgz",
+            "integrity": "sha512-tDW8hMkzad5oDtzsB70HIQQRBiTKrhfgwC/KkJeGsaNFTdWhKNt/BiE8c5yj19XiGyrxpbkOfH87qkNg1YGlOQ==",
             "requires": {
-                "@babel/helper-module-transforms": "^7.10.5",
+                "@babel/helper-module-transforms": "^7.12.1",
                 "@babel/helper-plugin-utils": "^7.10.4",
                 "babel-plugin-dynamic-import-node": "^2.3.3"
             }
         },
         "@babel/plugin-transform-modules-commonjs": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.10.4.tgz",
-            "integrity": "sha512-Xj7Uq5o80HDLlW64rVfDBhao6OX89HKUmb+9vWYaLXBZOma4gA6tw4Ni1O5qVDoZWUV0fxMYA0aYzOawz0l+1w==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.12.1.tgz",
+            "integrity": "sha512-dY789wq6l0uLY8py9c1B48V8mVL5gZh/+PQ5ZPrylPYsnAvnEMjqsUXkuoDVPeVK+0VyGar+D08107LzDQ6pag==",
             "requires": {
-                "@babel/helper-module-transforms": "^7.10.4",
+                "@babel/helper-module-transforms": "^7.12.1",
                 "@babel/helper-plugin-utils": "^7.10.4",
-                "@babel/helper-simple-access": "^7.10.4",
+                "@babel/helper-simple-access": "^7.12.1",
                 "babel-plugin-dynamic-import-node": "^2.3.3"
             }
         },
         "@babel/plugin-transform-modules-systemjs": {
-            "version": "7.10.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.10.5.tgz",
-            "integrity": "sha512-f4RLO/OL14/FP1AEbcsWMzpbUz6tssRaeQg11RH1BP/XnPpRoVwgeYViMFacnkaw4k4wjRSjn3ip1Uw9TaXuMw==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.12.1.tgz",
+            "integrity": "sha512-Hn7cVvOavVh8yvW6fLwveFqSnd7rbQN3zJvoPNyNaQSvgfKmDBO9U1YL9+PCXGRlZD9tNdWTy5ACKqMuzyn32Q==",
             "requires": {
                 "@babel/helper-hoist-variables": "^7.10.4",
-                "@babel/helper-module-transforms": "^7.10.5",
+                "@babel/helper-module-transforms": "^7.12.1",
                 "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/helper-validator-identifier": "^7.10.4",
                 "babel-plugin-dynamic-import-node": "^2.3.3"
             }
         },
         "@babel/plugin-transform-modules-umd": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.10.4.tgz",
-            "integrity": "sha512-mohW5q3uAEt8T45YT7Qc5ws6mWgJAaL/8BfWD9Dodo1A3RKWli8wTS+WiQ/knF+tXlPirW/1/MqzzGfCExKECA==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.12.1.tgz",
+            "integrity": "sha512-aEIubCS0KHKM0zUos5fIoQm+AZUMt1ZvMpqz0/H5qAQ7vWylr9+PLYurT+Ic7ID/bKLd4q8hDovaG3Zch2uz5Q==",
             "requires": {
-                "@babel/helper-module-transforms": "^7.10.4",
+                "@babel/helper-module-transforms": "^7.12.1",
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-named-capturing-groups-regex": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.10.4.tgz",
-            "integrity": "sha512-V6LuOnD31kTkxQPhKiVYzYC/Jgdq53irJC/xBSmqcNcqFGV+PER4l6rU5SH2Vl7bH9mLDHcc0+l9HUOe4RNGKA==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.12.1.tgz",
+            "integrity": "sha512-tB43uQ62RHcoDp9v2Nsf+dSM8sbNodbEicbQNA53zHz8pWUhsgHSJCGpt7daXxRydjb0KnfmB+ChXOv3oADp1Q==",
             "requires": {
-                "@babel/helper-create-regexp-features-plugin": "^7.10.4"
+                "@babel/helper-create-regexp-features-plugin": "^7.12.1"
             }
         },
         "@babel/plugin-transform-new-target": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.10.4.tgz",
-            "integrity": "sha512-YXwWUDAH/J6dlfwqlWsztI2Puz1NtUAubXhOPLQ5gjR/qmQ5U96DY4FQO8At33JN4XPBhrjB8I4eMmLROjjLjw==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.12.1.tgz",
+            "integrity": "sha512-+eW/VLcUL5L9IvJH7rT1sT0CzkdUTvPrXC2PXTn/7z7tXLBuKvezYbGdxD5WMRoyvyaujOq2fWoKl869heKjhw==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-object-super": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.10.4.tgz",
-            "integrity": "sha512-5iTw0JkdRdJvr7sY0vHqTpnruUpTea32JHmq/atIWqsnNussbRzjEDyWep8UNztt1B5IusBYg8Irb0bLbiEBCQ==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.12.1.tgz",
+            "integrity": "sha512-AvypiGJH9hsquNUn+RXVcBdeE3KHPZexWRdimhuV59cSoOt5kFBmqlByorAeUlGG2CJWd0U+4ZtNKga/TB0cAw==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4",
-                "@babel/helper-replace-supers": "^7.10.4"
+                "@babel/helper-replace-supers": "^7.12.1"
             }
         },
         "@babel/plugin-transform-parameters": {
-            "version": "7.10.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.5.tgz",
-            "integrity": "sha512-xPHwUj5RdFV8l1wuYiu5S9fqWGM2DrYc24TMvUiRrPVm+SM3XeqU9BcokQX/kEUe+p2RBwy+yoiR1w/Blq6ubw==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.12.1.tgz",
+            "integrity": "sha512-xq9C5EQhdPK23ZeCdMxl8bbRnAgHFrw5EOC3KJUsSylZqdkCaFEXxGSBuTSObOpiiHHNyb82es8M1QYgfQGfNg==",
             "requires": {
-                "@babel/helper-get-function-arity": "^7.10.4",
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-property-literals": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.10.4.tgz",
-            "integrity": "sha512-ofsAcKiUxQ8TY4sScgsGeR2vJIsfrzqvFb9GvJ5UdXDzl+MyYCaBj/FGzXuv7qE0aJcjWMILny1epqelnFlz8g==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.12.1.tgz",
+            "integrity": "sha512-6MTCR/mZ1MQS+AwZLplX4cEySjCpnIF26ToWo942nqn8hXSm7McaHQNeGx/pt7suI1TWOWMfa/NgBhiqSnX0cQ==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-react-constant-elements": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.10.4.tgz",
-            "integrity": "sha512-cYmQBW1pXrqBte1raMkAulXmi7rjg3VI6ZLg9QIic8Hq7BtYXaWuZSxsr2siOMI6SWwpxjWfnwhTUrd7JlAV7g==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.12.1.tgz",
+            "integrity": "sha512-KOHd0tIRLoER+J+8f9DblZDa1fLGPwaaN1DI1TVHuQFOpjHV22C3CUB3obeC4fexHY9nx+fH0hQNvLFFfA1mxA==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-react-display-name": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.10.4.tgz",
-            "integrity": "sha512-Zd4X54Mu9SBfPGnEcaGcOrVAYOtjT2on8QZkLKEq1S/tHexG39d9XXGZv19VfRrDjPJzFmPfTAqOQS1pfFOujw==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.12.1.tgz",
+            "integrity": "sha512-cAzB+UzBIrekfYxyLlFqf/OagTvHLcVBb5vpouzkYkBclRPraiygVnafvAoipErZLI8ANv8Ecn6E/m5qPXD26w==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-react-jsx": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.10.4.tgz",
-            "integrity": "sha512-L+MfRhWjX0eI7Js093MM6MacKU4M6dnCRa/QPDwYMxjljzSCzzlzKzj9Pk4P3OtrPcxr2N3znR419nr3Xw+65A==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.12.1.tgz",
+            "integrity": "sha512-RmKejwnT0T0QzQUzcbP5p1VWlpnP8QHtdhEtLG55ZDQnJNalbF3eeDyu3dnGKvGzFIQiBzFhBYTwvv435p9Xpw==",
             "requires": {
                 "@babel/helper-builder-react-jsx": "^7.10.4",
-                "@babel/helper-builder-react-jsx-experimental": "^7.10.4",
+                "@babel/helper-builder-react-jsx-experimental": "^7.12.1",
                 "@babel/helper-plugin-utils": "^7.10.4",
-                "@babel/plugin-syntax-jsx": "^7.10.4"
+                "@babel/plugin-syntax-jsx": "^7.12.1"
             }
         },
         "@babel/plugin-transform-react-jsx-development": {
-            "version": "7.11.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.11.5.tgz",
-            "integrity": "sha512-cImAmIlKJ84sDmpQzm4/0q/2xrXlDezQoixy3qoz1NJeZL/8PRon6xZtluvr4H4FzwlDGI5tCcFupMnXGtr+qw==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.12.1.tgz",
+            "integrity": "sha512-IilcGWdN1yNgEGOrB96jbTplRh+V2Pz1EoEwsKsHfX1a/L40cUYuD71Zepa7C+ujv7kJIxnDftWeZbKNEqZjCQ==",
             "requires": {
-                "@babel/helper-builder-react-jsx-experimental": "^7.11.5",
+                "@babel/helper-builder-react-jsx-experimental": "^7.12.1",
                 "@babel/helper-plugin-utils": "^7.10.4",
-                "@babel/plugin-syntax-jsx": "^7.10.4"
+                "@babel/plugin-syntax-jsx": "^7.12.1"
             }
         },
         "@babel/plugin-transform-react-jsx-self": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.10.4.tgz",
-            "integrity": "sha512-yOvxY2pDiVJi0axdTWHSMi5T0DILN+H+SaeJeACHKjQLezEzhLx9nEF9xgpBLPtkZsks9cnb5P9iBEi21En3gg==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.12.1.tgz",
+            "integrity": "sha512-FbpL0ieNWiiBB5tCldX17EtXgmzeEZjFrix72rQYeq9X6nUK38HCaxexzVQrZWXanxKJPKVVIU37gFjEQYkPkA==",
             "requires": {
-                "@babel/helper-plugin-utils": "^7.10.4",
-                "@babel/plugin-syntax-jsx": "^7.10.4"
+                "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-react-jsx-source": {
-            "version": "7.10.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.10.5.tgz",
-            "integrity": "sha512-wTeqHVkN1lfPLubRiZH3o73f4rfon42HpgxUSs86Nc+8QIcm/B9s8NNVXu/gwGcOyd7yDib9ikxoDLxJP0UiDA==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.12.1.tgz",
+            "integrity": "sha512-keQ5kBfjJNRc6zZN1/nVHCd6LLIHq4aUKcVnvE/2l+ZZROSbqoiGFRtT5t3Is89XJxBQaP7NLZX2jgGHdZvvFQ==",
             "requires": {
-                "@babel/helper-plugin-utils": "^7.10.4",
-                "@babel/plugin-syntax-jsx": "^7.10.4"
+                "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-react-pure-annotations": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.10.4.tgz",
-            "integrity": "sha512-+njZkqcOuS8RaPakrnR9KvxjoG1ASJWpoIv/doyWngId88JoFlPlISenGXjrVacZUIALGUr6eodRs1vmPnF23A==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.12.1.tgz",
+            "integrity": "sha512-RqeaHiwZtphSIUZ5I85PEH19LOSzxfuEazoY7/pWASCAIBuATQzpSVD+eT6MebeeZT2F4eSL0u4vw6n4Nm0Mjg==",
             "requires": {
                 "@babel/helper-annotate-as-pure": "^7.10.4",
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-regenerator": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.10.4.tgz",
-            "integrity": "sha512-3thAHwtor39A7C04XucbMg17RcZ3Qppfxr22wYzZNcVIkPHfpM9J0SO8zuCV6SZa265kxBJSrfKTvDCYqBFXGw==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.12.1.tgz",
+            "integrity": "sha512-gYrHqs5itw6i4PflFX3OdBPMQdPbF4bj2REIUxlMRUFk0/ZOAIpDFuViuxPjUL7YC8UPnf+XG7/utJvqXdPKng==",
             "requires": {
                 "regenerator-transform": "^0.14.2"
             }
         },
         "@babel/plugin-transform-reserved-words": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.10.4.tgz",
-            "integrity": "sha512-hGsw1O6Rew1fkFbDImZIEqA8GoidwTAilwCyWqLBM9f+e/u/sQMQu7uX6dyokfOayRuuVfKOW4O7HvaBWM+JlQ==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.12.1.tgz",
+            "integrity": "sha512-pOnUfhyPKvZpVyBHhSBoX8vfA09b7r00Pmm1sH+29ae2hMTKVmSp4Ztsr8KBKjLjx17H0eJqaRC3bR2iThM54A==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-shorthand-properties": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.10.4.tgz",
-            "integrity": "sha512-AC2K/t7o07KeTIxMoHneyX90v3zkm5cjHJEokrPEAGEy3UCp8sLKfnfOIGdZ194fyN4wfX/zZUWT9trJZ0qc+Q==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.1.tgz",
+            "integrity": "sha512-GFZS3c/MhX1OusqB1MZ1ct2xRzX5ppQh2JU1h2Pnfk88HtFTM+TWQqJNfwkmxtPQtb/s1tk87oENfXJlx7rSDw==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-spread": {
-            "version": "7.11.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.11.0.tgz",
-            "integrity": "sha512-UwQYGOqIdQJe4aWNyS7noqAnN2VbaczPLiEtln+zPowRNlD+79w3oi2TWfYe0eZgd+gjZCbsydN7lzWysDt+gw==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.12.1.tgz",
+            "integrity": "sha512-vuLp8CP0BE18zVYjsEBZ5xoCecMK6LBMMxYzJnh01rxQRvhNhH1csMMmBfNo5tGpGO+NhdSNW2mzIvBu3K1fng==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.11.0"
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.12.1"
             }
         },
         "@babel/plugin-transform-sticky-regex": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.10.4.tgz",
-            "integrity": "sha512-Ddy3QZfIbEV0VYcVtFDCjeE4xwVTJWTmUtorAJkn6u/92Z/nWJNV+mILyqHKrUxXYKA2EoCilgoPePymKL4DvQ==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.12.1.tgz",
+            "integrity": "sha512-CiUgKQ3AGVk7kveIaPEET1jNDhZZEl1RPMWdTBE1799bdz++SwqDHStmxfCtDfBhQgCl38YRiSnrMuUMZIWSUQ==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4",
                 "@babel/helper-regex": "^7.10.4"
             }
         },
         "@babel/plugin-transform-template-literals": {
-            "version": "7.10.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.5.tgz",
-            "integrity": "sha512-V/lnPGIb+KT12OQikDvgSuesRX14ck5FfJXt6+tXhdkJ+Vsd0lDCVtF6jcB4rNClYFzaB2jusZ+lNISDk2mMMw==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.12.1.tgz",
+            "integrity": "sha512-b4Zx3KHi+taXB1dVRBhVJtEPi9h1THCeKmae2qP0YdUHIFhVjtpqqNfxeVAa1xeHVhAy4SbHxEwx5cltAu5apw==",
             "requires": {
-                "@babel/helper-annotate-as-pure": "^7.10.4",
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-typeof-symbol": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.10.4.tgz",
-            "integrity": "sha512-QqNgYwuuW0y0H+kUE/GWSR45t/ccRhe14Fs/4ZRouNNQsyd4o3PG4OtHiIrepbM2WKUBDAXKCAK/Lk4VhzTaGA==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.12.1.tgz",
+            "integrity": "sha512-EPGgpGy+O5Kg5pJFNDKuxt9RdmTgj5sgrus2XVeMp/ZIbOESadgILUbm50SNpghOh3/6yrbsH+NB5+WJTmsA7Q==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-typescript": {
-            "version": "7.11.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.11.0.tgz",
-            "integrity": "sha512-edJsNzTtvb3MaXQwj8403B7mZoGu9ElDJQZOKjGUnvilquxBA3IQoEIOvkX/1O8xfAsnHS/oQhe2w/IXrr+w0w==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.12.1.tgz",
+            "integrity": "sha512-VrsBByqAIntM+EYMqSm59SiMEf7qkmI9dqMt6RbD/wlwueWmYcI0FFK5Fj47pP6DRZm+3teXjosKlwcZJ5lIMw==",
             "requires": {
-                "@babel/helper-create-class-features-plugin": "^7.10.5",
+                "@babel/helper-create-class-features-plugin": "^7.12.1",
                 "@babel/helper-plugin-utils": "^7.10.4",
-                "@babel/plugin-syntax-typescript": "^7.10.4"
+                "@babel/plugin-syntax-typescript": "^7.12.1"
             }
         },
         "@babel/plugin-transform-unicode-escapes": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.10.4.tgz",
-            "integrity": "sha512-y5XJ9waMti2J+e7ij20e+aH+fho7Wb7W8rNuu72aKRwCHFqQdhkdU2lo3uZ9tQuboEJcUFayXdARhcxLQ3+6Fg==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.12.1.tgz",
+            "integrity": "sha512-I8gNHJLIc7GdApm7wkVnStWssPNbSRMPtgHdmH3sRM1zopz09UWPS4x5V4n1yz/MIWTVnJ9sp6IkuXdWM4w+2Q==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-unicode-regex": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.10.4.tgz",
-            "integrity": "sha512-wNfsc4s8N2qnIwpO/WP2ZiSyjfpTamT2C9V9FDH/Ljub9zw6P3SjkXcFmc0RQUt96k2fmIvtla2MMjgTwIAC+A==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.12.1.tgz",
+            "integrity": "sha512-SqH4ClNngh/zGwHZOOQMTD+e8FGWexILV+ePMyiDJttAWRh5dhDL8rcl5lSgU3Huiq6Zn6pWTMvdPAb21Dwdyg==",
             "requires": {
-                "@babel/helper-create-regexp-features-plugin": "^7.10.4",
+                "@babel/helper-create-regexp-features-plugin": "^7.12.1",
                 "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/preset-env": {
-            "version": "7.11.5",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.11.5.tgz",
-            "integrity": "sha512-kXqmW1jVcnB2cdueV+fyBM8estd5mlNfaQi6lwLgRwCby4edpavgbFhiBNjmWA3JpB/yZGSISa7Srf+TwxDQoA==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.12.1.tgz",
+            "integrity": "sha512-H8kxXmtPaAGT7TyBvSSkoSTUK6RHh61So05SyEbpmr0MCZrsNYn7mGMzzeYoOUCdHzww61k8XBft2TaES+xPLg==",
             "requires": {
-                "@babel/compat-data": "^7.11.0",
-                "@babel/helper-compilation-targets": "^7.10.4",
-                "@babel/helper-module-imports": "^7.10.4",
+                "@babel/compat-data": "^7.12.1",
+                "@babel/helper-compilation-targets": "^7.12.1",
+                "@babel/helper-module-imports": "^7.12.1",
                 "@babel/helper-plugin-utils": "^7.10.4",
-                "@babel/plugin-proposal-async-generator-functions": "^7.10.4",
-                "@babel/plugin-proposal-class-properties": "^7.10.4",
-                "@babel/plugin-proposal-dynamic-import": "^7.10.4",
-                "@babel/plugin-proposal-export-namespace-from": "^7.10.4",
-                "@babel/plugin-proposal-json-strings": "^7.10.4",
-                "@babel/plugin-proposal-logical-assignment-operators": "^7.11.0",
-                "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
-                "@babel/plugin-proposal-numeric-separator": "^7.10.4",
-                "@babel/plugin-proposal-object-rest-spread": "^7.11.0",
-                "@babel/plugin-proposal-optional-catch-binding": "^7.10.4",
-                "@babel/plugin-proposal-optional-chaining": "^7.11.0",
-                "@babel/plugin-proposal-private-methods": "^7.10.4",
-                "@babel/plugin-proposal-unicode-property-regex": "^7.10.4",
+                "@babel/helper-validator-option": "^7.12.1",
+                "@babel/plugin-proposal-async-generator-functions": "^7.12.1",
+                "@babel/plugin-proposal-class-properties": "^7.12.1",
+                "@babel/plugin-proposal-dynamic-import": "^7.12.1",
+                "@babel/plugin-proposal-export-namespace-from": "^7.12.1",
+                "@babel/plugin-proposal-json-strings": "^7.12.1",
+                "@babel/plugin-proposal-logical-assignment-operators": "^7.12.1",
+                "@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.1",
+                "@babel/plugin-proposal-numeric-separator": "^7.12.1",
+                "@babel/plugin-proposal-object-rest-spread": "^7.12.1",
+                "@babel/plugin-proposal-optional-catch-binding": "^7.12.1",
+                "@babel/plugin-proposal-optional-chaining": "^7.12.1",
+                "@babel/plugin-proposal-private-methods": "^7.12.1",
+                "@babel/plugin-proposal-unicode-property-regex": "^7.12.1",
                 "@babel/plugin-syntax-async-generators": "^7.8.0",
-                "@babel/plugin-syntax-class-properties": "^7.10.4",
+                "@babel/plugin-syntax-class-properties": "^7.12.1",
                 "@babel/plugin-syntax-dynamic-import": "^7.8.0",
                 "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
                 "@babel/plugin-syntax-json-strings": "^7.8.0",
@@ -1277,45 +1043,42 @@
                 "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
                 "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
                 "@babel/plugin-syntax-optional-chaining": "^7.8.0",
-                "@babel/plugin-syntax-top-level-await": "^7.10.4",
-                "@babel/plugin-transform-arrow-functions": "^7.10.4",
-                "@babel/plugin-transform-async-to-generator": "^7.10.4",
-                "@babel/plugin-transform-block-scoped-functions": "^7.10.4",
-                "@babel/plugin-transform-block-scoping": "^7.10.4",
-                "@babel/plugin-transform-classes": "^7.10.4",
-                "@babel/plugin-transform-computed-properties": "^7.10.4",
-                "@babel/plugin-transform-destructuring": "^7.10.4",
-                "@babel/plugin-transform-dotall-regex": "^7.10.4",
-                "@babel/plugin-transform-duplicate-keys": "^7.10.4",
-                "@babel/plugin-transform-exponentiation-operator": "^7.10.4",
-                "@babel/plugin-transform-for-of": "^7.10.4",
-                "@babel/plugin-transform-function-name": "^7.10.4",
-                "@babel/plugin-transform-literals": "^7.10.4",
-                "@babel/plugin-transform-member-expression-literals": "^7.10.4",
-                "@babel/plugin-transform-modules-amd": "^7.10.4",
-                "@babel/plugin-transform-modules-commonjs": "^7.10.4",
-                "@babel/plugin-transform-modules-systemjs": "^7.10.4",
-                "@babel/plugin-transform-modules-umd": "^7.10.4",
-                "@babel/plugin-transform-named-capturing-groups-regex": "^7.10.4",
-                "@babel/plugin-transform-new-target": "^7.10.4",
-                "@babel/plugin-transform-object-super": "^7.10.4",
-                "@babel/plugin-transform-parameters": "^7.10.4",
-                "@babel/plugin-transform-property-literals": "^7.10.4",
-                "@babel/plugin-transform-regenerator": "^7.10.4",
-                "@babel/plugin-transform-reserved-words": "^7.10.4",
-                "@babel/plugin-transform-shorthand-properties": "^7.10.4",
-                "@babel/plugin-transform-spread": "^7.11.0",
-                "@babel/plugin-transform-sticky-regex": "^7.10.4",
-                "@babel/plugin-transform-template-literals": "^7.10.4",
-                "@babel/plugin-transform-typeof-symbol": "^7.10.4",
-                "@babel/plugin-transform-unicode-escapes": "^7.10.4",
-                "@babel/plugin-transform-unicode-regex": "^7.10.4",
+                "@babel/plugin-syntax-top-level-await": "^7.12.1",
+                "@babel/plugin-transform-arrow-functions": "^7.12.1",
+                "@babel/plugin-transform-async-to-generator": "^7.12.1",
+                "@babel/plugin-transform-block-scoped-functions": "^7.12.1",
+                "@babel/plugin-transform-block-scoping": "^7.12.1",
+                "@babel/plugin-transform-classes": "^7.12.1",
+                "@babel/plugin-transform-computed-properties": "^7.12.1",
+                "@babel/plugin-transform-destructuring": "^7.12.1",
+                "@babel/plugin-transform-dotall-regex": "^7.12.1",
+                "@babel/plugin-transform-duplicate-keys": "^7.12.1",
+                "@babel/plugin-transform-exponentiation-operator": "^7.12.1",
+                "@babel/plugin-transform-for-of": "^7.12.1",
+                "@babel/plugin-transform-function-name": "^7.12.1",
+                "@babel/plugin-transform-literals": "^7.12.1",
+                "@babel/plugin-transform-member-expression-literals": "^7.12.1",
+                "@babel/plugin-transform-modules-amd": "^7.12.1",
+                "@babel/plugin-transform-modules-commonjs": "^7.12.1",
+                "@babel/plugin-transform-modules-systemjs": "^7.12.1",
+                "@babel/plugin-transform-modules-umd": "^7.12.1",
+                "@babel/plugin-transform-named-capturing-groups-regex": "^7.12.1",
+                "@babel/plugin-transform-new-target": "^7.12.1",
+                "@babel/plugin-transform-object-super": "^7.12.1",
+                "@babel/plugin-transform-parameters": "^7.12.1",
+                "@babel/plugin-transform-property-literals": "^7.12.1",
+                "@babel/plugin-transform-regenerator": "^7.12.1",
+                "@babel/plugin-transform-reserved-words": "^7.12.1",
+                "@babel/plugin-transform-shorthand-properties": "^7.12.1",
+                "@babel/plugin-transform-spread": "^7.12.1",
+                "@babel/plugin-transform-sticky-regex": "^7.12.1",
+                "@babel/plugin-transform-template-literals": "^7.12.1",
+                "@babel/plugin-transform-typeof-symbol": "^7.12.1",
+                "@babel/plugin-transform-unicode-escapes": "^7.12.1",
+                "@babel/plugin-transform-unicode-regex": "^7.12.1",
                 "@babel/preset-modules": "^0.1.3",
-                "@babel/types": "^7.11.5",
-                "browserslist": "^4.12.0",
+                "@babel/types": "^7.12.1",
                 "core-js-compat": "^3.6.2",
-                "invariant": "^2.2.2",
-                "levenary": "^1.1.1",
                 "semver": "^5.5.0"
             },
             "dependencies": {
@@ -1327,12 +1090,12 @@
             }
         },
         "@babel/preset-flow": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.10.4.tgz",
-            "integrity": "sha512-XI6l1CptQCOBv+ZKYwynyswhtOKwpZZp5n0LG1QKCo8erRhqjoQV6nvx61Eg30JHpysWQSBwA2AWRU3pBbSY5g==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.12.1.tgz",
+            "integrity": "sha512-UAoyMdioAhM6H99qPoKvpHMzxmNVXno8GYU/7vZmGaHk6/KqfDYL1W0NxszVbJ2EP271b7e6Ox+Vk2A9QsB3Sw==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4",
-                "@babel/plugin-transform-flow-strip-types": "^7.10.4"
+                "@babel/plugin-transform-flow-strip-types": "^7.12.1"
             }
         },
         "@babel/preset-modules": {
@@ -1348,32 +1111,32 @@
             }
         },
         "@babel/preset-react": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.10.4.tgz",
-            "integrity": "sha512-BrHp4TgOIy4M19JAfO1LhycVXOPWdDbTRep7eVyatf174Hff+6Uk53sDyajqZPu8W1qXRBiYOfIamek6jA7YVw==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.12.1.tgz",
+            "integrity": "sha512-euCExymHCi0qB9u5fKw7rvlw7AZSjw/NaB9h7EkdTt5+yHRrXdiRTh7fkG3uBPpJg82CqLfp1LHLqWGSCrab+g==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4",
-                "@babel/plugin-transform-react-display-name": "^7.10.4",
-                "@babel/plugin-transform-react-jsx": "^7.10.4",
-                "@babel/plugin-transform-react-jsx-development": "^7.10.4",
-                "@babel/plugin-transform-react-jsx-self": "^7.10.4",
-                "@babel/plugin-transform-react-jsx-source": "^7.10.4",
-                "@babel/plugin-transform-react-pure-annotations": "^7.10.4"
+                "@babel/plugin-transform-react-display-name": "^7.12.1",
+                "@babel/plugin-transform-react-jsx": "^7.12.1",
+                "@babel/plugin-transform-react-jsx-development": "^7.12.1",
+                "@babel/plugin-transform-react-jsx-self": "^7.12.1",
+                "@babel/plugin-transform-react-jsx-source": "^7.12.1",
+                "@babel/plugin-transform-react-pure-annotations": "^7.12.1"
             }
         },
         "@babel/preset-typescript": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.10.4.tgz",
-            "integrity": "sha512-SdYnvGPv+bLlwkF2VkJnaX/ni1sMNetcGI1+nThF1gyv6Ph8Qucc4ZZAjM5yZcE/AKRXIOTZz7eSRDWOEjPyRQ==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.12.1.tgz",
+            "integrity": "sha512-hNK/DhmoJPsksdHuI/RVrcEws7GN5eamhi28JkO52MqIxU8Z0QpmiSOQxZHWOHV7I3P4UjHV97ay4TcamMA6Kw==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4",
-                "@babel/plugin-transform-typescript": "^7.10.4"
+                "@babel/plugin-transform-typescript": "^7.12.1"
             }
         },
         "@babel/register": {
-            "version": "7.11.5",
-            "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.11.5.tgz",
-            "integrity": "sha512-CAml0ioKX+kOAvBQDHa/+t1fgOt3qkTIz0TrRtRAT6XY0m5qYZXR85k6/sLCNPMGhYDlCFHCYuU0ybTJbvlC6w==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.12.1.tgz",
+            "integrity": "sha512-XWcmseMIncOjoydKZnWvWi0/5CUCD+ZYKhRwgYlWOrA8fGZ/FjuLRpqtIhLOVD/fvR1b9DQHtZPn68VvhpYf+Q==",
             "requires": {
                 "find-cache-dir": "^2.0.0",
                 "lodash": "^4.17.19",
@@ -1383,17 +1146,17 @@
             }
         },
         "@babel/runtime": {
-            "version": "7.11.2",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-            "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
+            "integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
             "requires": {
                 "regenerator-runtime": "^0.13.4"
             }
         },
         "@babel/runtime-corejs3": {
-            "version": "7.11.2",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz",
-            "integrity": "sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.1.tgz",
+            "integrity": "sha512-umhPIcMrlBZ2aTWlWjUseW9LjQKxi1dpFlQS8DzsxB//5K+u6GLTC/JliPKHsd5kJVPIU6X/Hy0YvWOYPcMxBw==",
             "dev": true,
             "requires": {
                 "core-js-pure": "^3.0.0",
@@ -1411,25 +1174,25 @@
             }
         },
         "@babel/traverse": {
-            "version": "7.11.5",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
-            "integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.1.tgz",
+            "integrity": "sha512-MA3WPoRt1ZHo2ZmoGKNqi20YnPt0B1S0GTZEPhhd+hw2KGUzBlHuVunj6K4sNuK+reEvyiPwtp0cpaqLzJDmAw==",
             "requires": {
                 "@babel/code-frame": "^7.10.4",
-                "@babel/generator": "^7.11.5",
+                "@babel/generator": "^7.12.1",
                 "@babel/helper-function-name": "^7.10.4",
                 "@babel/helper-split-export-declaration": "^7.11.0",
-                "@babel/parser": "^7.11.5",
-                "@babel/types": "^7.11.5",
+                "@babel/parser": "^7.12.1",
+                "@babel/types": "^7.12.1",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0",
                 "lodash": "^4.17.19"
             }
         },
         "@babel/types": {
-            "version": "7.11.5",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-            "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
+            "integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
             "requires": {
                 "@babel/helper-validator-identifier": "^7.10.4",
                 "lodash": "^4.17.19",
@@ -1440,6 +1203,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@base2/pretty-print-object/-/pretty-print-object-1.0.0.tgz",
             "integrity": "sha512-4Th98KlMHr5+JkxfcoDT//6vY8vM+iSPrLNpHhRyLx2CFYi8e2RfqPLdpbnpo0Q5lQC5hNB79yes07zb02fvCw==",
+            "dev": true
+        },
+        "@bcoe/v8-coverage": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+            "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
         },
         "@cnakazawa/watch": {
@@ -1627,22 +1396,393 @@
             "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
             "dev": true
         },
+        "@jest/console": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.6.1.tgz",
+            "integrity": "sha512-cjqcXepwC5M+VeIhwT6Xpi/tT4AiNzlIx8SMJ9IihduHnsSrnWNvTBfKIpmqOOCNOPqtbBx6w2JqfoLOJguo8g==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.6.1",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "jest-message-util": "^26.6.1",
+                "jest-util": "^26.6.1",
+                "slash": "^3.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "slash": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+                    "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "@jest/core": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.6.1.tgz",
+            "integrity": "sha512-p4F0pgK3rKnoS9olXXXOkbus1Bsu6fd8pcvLMPsUy4CVXZ8WSeiwQ1lK5hwkCIqJ+amZOYPd778sbPha/S8Srw==",
+            "dev": true,
+            "requires": {
+                "@jest/console": "^26.6.1",
+                "@jest/reporters": "^26.6.1",
+                "@jest/test-result": "^26.6.1",
+                "@jest/transform": "^26.6.1",
+                "@jest/types": "^26.6.1",
+                "@types/node": "*",
+                "ansi-escapes": "^4.2.1",
+                "chalk": "^4.0.0",
+                "exit": "^0.1.2",
+                "graceful-fs": "^4.2.4",
+                "jest-changed-files": "^26.6.1",
+                "jest-config": "^26.6.1",
+                "jest-haste-map": "^26.6.1",
+                "jest-message-util": "^26.6.1",
+                "jest-regex-util": "^26.0.0",
+                "jest-resolve": "^26.6.1",
+                "jest-resolve-dependencies": "^26.6.1",
+                "jest-runner": "^26.6.1",
+                "jest-runtime": "^26.6.1",
+                "jest-snapshot": "^26.6.1",
+                "jest-util": "^26.6.1",
+                "jest-validate": "^26.6.1",
+                "jest-watcher": "^26.6.1",
+                "micromatch": "^4.0.2",
+                "p-each-series": "^2.1.0",
+                "rimraf": "^3.0.0",
+                "slash": "^3.0.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "rimraf": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+                    "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                },
+                "slash": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+                    "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "@jest/create-cache-key-function": {
+            "version": "26.5.0",
+            "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-26.5.0.tgz",
+            "integrity": "sha512-DJ+pEBUIqarrbv1W/C39f9YH0rJ4wsXZ/VC6JafJPlHW2HOucKceeaqTOQj9MEDQZjySxMLkOq5mfXZXNZcmWw==",
+            "dev": true
+        },
+        "@jest/environment": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.6.1.tgz",
+            "integrity": "sha512-GNvHwkOFJtNgSwdzH9flUPzF9AYAZhUg124CBoQcwcZCM9s5TLz8Y3fMtiaWt4ffbigoetjGk5PU2Dd8nLrSEw==",
+            "dev": true,
+            "requires": {
+                "@jest/fake-timers": "^26.6.1",
+                "@jest/types": "^26.6.1",
+                "@types/node": "*",
+                "jest-mock": "^26.6.1"
+            }
+        },
+        "@jest/fake-timers": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.6.1.tgz",
+            "integrity": "sha512-T/SkMLgOquenw/nIisBRD6XAYpFir0kNuclYLkse5BpzeDUukyBr+K31xgAo9M0hgjU9ORlekAYPSzc0DKfmKg==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.6.1",
+                "@sinonjs/fake-timers": "^6.0.1",
+                "@types/node": "*",
+                "jest-message-util": "^26.6.1",
+                "jest-mock": "^26.6.1",
+                "jest-util": "^26.6.1"
+            }
+        },
+        "@jest/globals": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.6.1.tgz",
+            "integrity": "sha512-acxXsSguuLV/CeMYmBseefw6apO7NuXqpE+v5r3yD9ye2PY7h1nS20vY7Obk2w6S7eJO4OIAJeDnoGcLC/McEQ==",
+            "dev": true,
+            "requires": {
+                "@jest/environment": "^26.6.1",
+                "@jest/types": "^26.6.1",
+                "expect": "^26.6.1"
+            }
+        },
+        "@jest/reporters": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.6.1.tgz",
+            "integrity": "sha512-J6OlXVFY3q1SXWJhjme5i7qT/BAZSikdOK2t8Ht5OS32BDo6KfG5CzIzzIFnAVd82/WWbc9Hb7SJ/jwSvVH9YA==",
+            "dev": true,
+            "requires": {
+                "@bcoe/v8-coverage": "^0.2.3",
+                "@jest/console": "^26.6.1",
+                "@jest/test-result": "^26.6.1",
+                "@jest/transform": "^26.6.1",
+                "@jest/types": "^26.6.1",
+                "chalk": "^4.0.0",
+                "collect-v8-coverage": "^1.0.0",
+                "exit": "^0.1.2",
+                "glob": "^7.1.2",
+                "graceful-fs": "^4.2.4",
+                "istanbul-lib-coverage": "^3.0.0",
+                "istanbul-lib-instrument": "^4.0.3",
+                "istanbul-lib-report": "^3.0.0",
+                "istanbul-lib-source-maps": "^4.0.0",
+                "istanbul-reports": "^3.0.2",
+                "jest-haste-map": "^26.6.1",
+                "jest-resolve": "^26.6.1",
+                "jest-util": "^26.6.1",
+                "jest-worker": "^26.6.1",
+                "node-notifier": "^8.0.0",
+                "slash": "^3.0.0",
+                "source-map": "^0.6.0",
+                "string-length": "^4.0.1",
+                "terminal-link": "^2.0.0",
+                "v8-to-istanbul": "^6.0.1"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "slash": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+                    "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "@jest/source-map": {
+            "version": "26.5.0",
+            "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.5.0.tgz",
+            "integrity": "sha512-jWAw9ZwYHJMe9eZq/WrsHlwF8E3hM9gynlcDpOyCb9bR8wEd9ZNBZCi7/jZyzHxC7t3thZ10gO2IDhu0bPKS5g==",
+            "dev": true,
+            "requires": {
+                "callsites": "^3.0.0",
+                "graceful-fs": "^4.2.4",
+                "source-map": "^0.6.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "@jest/test-result": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.6.1.tgz",
+            "integrity": "sha512-wqAgIerIN2gSdT2A8WeA5+AFh9XQBqYGf8etK143yng3qYd0mF0ie2W5PVmgnjw4VDU6ammI9NdXrKgNhreawg==",
+            "dev": true,
+            "requires": {
+                "@jest/console": "^26.6.1",
+                "@jest/types": "^26.6.1",
+                "@types/istanbul-lib-coverage": "^2.0.0",
+                "collect-v8-coverage": "^1.0.0"
+            }
+        },
+        "@jest/test-sequencer": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.6.1.tgz",
+            "integrity": "sha512-0csqA/XApZiNeTIPYh6koIDCACSoR6hi29T61tKJMtCZdEC+tF3PoNt7MS0oK/zKC6daBgCbqXxia5ztr/NyCQ==",
+            "dev": true,
+            "requires": {
+                "@jest/test-result": "^26.6.1",
+                "graceful-fs": "^4.2.4",
+                "jest-haste-map": "^26.6.1",
+                "jest-runner": "^26.6.1",
+                "jest-runtime": "^26.6.1"
+            }
+        },
         "@jest/transform": {
-            "version": "26.5.2",
-            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.5.2.tgz",
-            "integrity": "sha512-AUNjvexh+APhhmS8S+KboPz+D3pCxPvEAGduffaAJYxIFxGi/ytZQkrqcKDUU0ERBAo5R7087fyOYr2oms1seg==",
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.6.1.tgz",
+            "integrity": "sha512-oNFAqVtqRxZRx6vXL3I4bPKUK0BIlEeaalkwxyQGGI8oXDQBtYQBpiMe5F7qPs4QdvvFYB42gPGIMMcxXaBBxQ==",
             "dev": true,
             "requires": {
                 "@babel/core": "^7.1.0",
-                "@jest/types": "^26.5.2",
+                "@jest/types": "^26.6.1",
                 "babel-plugin-istanbul": "^6.0.0",
                 "chalk": "^4.0.0",
                 "convert-source-map": "^1.4.0",
                 "fast-json-stable-stringify": "^2.0.0",
                 "graceful-fs": "^4.2.4",
-                "jest-haste-map": "^26.5.2",
+                "jest-haste-map": "^26.6.1",
                 "jest-regex-util": "^26.0.0",
-                "jest-util": "^26.5.2",
+                "jest-util": "^26.6.1",
                 "micromatch": "^4.0.2",
                 "pirates": "^4.0.1",
                 "slash": "^3.0.0",
@@ -1690,6 +1830,12 @@
                     "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
                     "dev": true
                 },
+                "slash": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+                    "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+                    "dev": true
+                },
                 "source-map": {
                     "version": "0.6.1",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -1708,9 +1854,9 @@
             }
         },
         "@jest/types": {
-            "version": "26.5.2",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
-            "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+            "integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
             "dev": true,
             "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1772,53 +1918,107 @@
             }
         },
         "@mdx-js/loader": {
-            "version": "1.6.18",
-            "resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-1.6.18.tgz",
-            "integrity": "sha512-mCIt3dFc4p7y3ZqVda07grZDWgMcwSePT3k9vQfgfUcGWLeTFhp46fTbzagXVR/izldFSBLVYkouuH2PaI7Ecw==",
+            "version": "1.6.19",
+            "resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-1.6.19.tgz",
+            "integrity": "sha512-sUOVonSzd6w821p8jCL2ET5KK24cu1w3igGwcXG/T+ZTl81EjUR9Tbv4Q50jxWS9umtmk5GcdAZndnDmpRHZXQ==",
             "dev": true,
             "requires": {
-                "@mdx-js/mdx": "1.6.18",
-                "@mdx-js/react": "1.6.18",
+                "@mdx-js/mdx": "1.6.19",
+                "@mdx-js/react": "1.6.19",
                 "loader-utils": "2.0.0"
+            },
+            "dependencies": {
+                "loader-utils": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+                    "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+                    "dev": true,
+                    "requires": {
+                        "big.js": "^5.2.2",
+                        "emojis-list": "^3.0.0",
+                        "json5": "^2.1.2"
+                    }
+                }
             }
         },
         "@mdx-js/mdx": {
-            "version": "1.6.18",
-            "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-1.6.18.tgz",
-            "integrity": "sha512-RXtdFBP3cnf/RILx/ipp5TsSY1k75bYYmjorv7jTaPcHPQwhQdI6K4TrVUed/GL4f8zX5TN2QwO5g+3E/8RsXA==",
+            "version": "1.6.19",
+            "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-1.6.19.tgz",
+            "integrity": "sha512-L3eLhEFnV/2bcb9XwOegsRmLHd1oEDQPtTBVezhptQ5U1YM+/WQNzx1apjzVTAyukwOanUXnTUMjRUtqJNgFCg==",
             "dev": true,
             "requires": {
                 "@babel/core": "7.11.6",
                 "@babel/plugin-syntax-jsx": "7.10.4",
                 "@babel/plugin-syntax-object-rest-spread": "7.8.3",
-                "@mdx-js/util": "1.6.18",
-                "babel-plugin-apply-mdx-type-prop": "1.6.18",
-                "babel-plugin-extract-import-names": "1.6.18",
+                "@mdx-js/util": "1.6.19",
+                "babel-plugin-apply-mdx-type-prop": "1.6.19",
+                "babel-plugin-extract-import-names": "1.6.19",
                 "camelcase-css": "2.0.1",
                 "detab": "2.0.3",
                 "hast-util-raw": "6.0.1",
                 "lodash.uniq": "4.5.0",
                 "mdast-util-to-hast": "9.1.1",
                 "remark-footnotes": "2.0.0",
-                "remark-mdx": "1.6.18",
+                "remark-mdx": "1.6.19",
                 "remark-parse": "8.0.3",
                 "remark-squeeze-paragraphs": "4.0.0",
                 "style-to-object": "0.3.0",
                 "unified": "9.2.0",
                 "unist-builder": "2.0.3",
                 "unist-util-visit": "2.0.3"
+            },
+            "dependencies": {
+                "@babel/core": {
+                    "version": "7.11.6",
+                    "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
+                    "integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.10.4",
+                        "@babel/generator": "^7.11.6",
+                        "@babel/helper-module-transforms": "^7.11.0",
+                        "@babel/helpers": "^7.10.4",
+                        "@babel/parser": "^7.11.5",
+                        "@babel/template": "^7.10.4",
+                        "@babel/traverse": "^7.11.5",
+                        "@babel/types": "^7.11.5",
+                        "convert-source-map": "^1.7.0",
+                        "debug": "^4.1.0",
+                        "gensync": "^1.0.0-beta.1",
+                        "json5": "^2.1.2",
+                        "lodash": "^4.17.19",
+                        "resolve": "^1.3.2",
+                        "semver": "^5.4.1",
+                        "source-map": "^0.5.0"
+                    }
+                },
+                "@babel/plugin-syntax-jsx": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.10.4.tgz",
+                    "integrity": "sha512-KCg9mio9jwiARCB7WAcQ7Y1q+qicILjoK8LP/VkPkEKaf5dkaZZK1EcTe91a3JJlZ3qy6L5s9X52boEYi8DM9g==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.10.4"
+                    }
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
+                }
             }
         },
         "@mdx-js/react": {
-            "version": "1.6.18",
-            "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.18.tgz",
-            "integrity": "sha512-aFHsZVu7r9WamlP+WO/lyvHHZAubkQjkcRYlvS7fQElypfJvjKdHevjC3xiqlsQpasx/4KqRMoEIb++wNtd+6w==",
+            "version": "1.6.19",
+            "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.19.tgz",
+            "integrity": "sha512-RS37Tagqyp2R0XFPoUZeSbZC5uJQRPhqOHWeT1LEwxESjMWb3VORHz7E827ldeQr3UW6VEQEyq/THegu+bLj6A==",
             "dev": true
         },
         "@mdx-js/util": {
-            "version": "1.6.18",
-            "resolved": "https://registry.npmjs.org/@mdx-js/util/-/util-1.6.18.tgz",
-            "integrity": "sha512-axMe+NoLF55OlXPbhRn4GNCHcL1f5W3V3c0dWzg05S9JXm3Ecpxzxaht3g3vTP0dcqBL/yh/xCvzK0ZpO54Eug==",
+            "version": "1.6.19",
+            "resolved": "https://registry.npmjs.org/@mdx-js/util/-/util-1.6.19.tgz",
+            "integrity": "sha512-bkkQNSHz3xSr3KRHUQ2Qk2XhewvvXAOUqjIUKwcQuL4ijOA4tUHZfUgXExi5CpMysrX7izcsyICtXjZHlfJUjg==",
             "dev": true
         },
         "@mrmlnc/readdir-enhanced": {
@@ -1828,6 +2028,160 @@
             "requires": {
                 "call-me-maybe": "^1.0.1",
                 "glob-to-regexp": "^0.3.0"
+            }
+        },
+        "@nicolo-ribaudo/chokidar-2": {
+            "version": "2.1.8",
+            "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8.tgz",
+            "integrity": "sha512-FohwULwAebCUKi/akMFyGi7jfc7JXTeMHzKxuP3umRd9mK/2Y7/SMBSI2jX+YLopPXi+PF9l307NmpfxTdCegA==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "chokidar": "2.1.8"
+            },
+            "dependencies": {
+                "anymatch": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+                    "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "micromatch": "^3.1.4",
+                        "normalize-path": "^2.1.1"
+                    },
+                    "dependencies": {
+                        "normalize-path": {
+                            "version": "2.1.1",
+                            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "remove-trailing-separator": "^1.0.1"
+                            }
+                        }
+                    }
+                },
+                "binary-extensions": {
+                    "version": "1.13.1",
+                    "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+                    "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+                    "dev": true,
+                    "optional": true
+                },
+                "chokidar": {
+                    "version": "2.1.8",
+                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+                    "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "anymatch": "^2.0.0",
+                        "async-each": "^1.0.1",
+                        "braces": "^2.3.2",
+                        "fsevents": "^1.2.7",
+                        "glob-parent": "^3.1.0",
+                        "inherits": "^2.0.3",
+                        "is-binary-path": "^1.0.0",
+                        "is-glob": "^4.0.0",
+                        "normalize-path": "^3.0.0",
+                        "path-is-absolute": "^1.0.0",
+                        "readdirp": "^2.2.1",
+                        "upath": "^1.1.1"
+                    }
+                },
+                "fsevents": {
+                    "version": "1.2.13",
+                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+                    "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+                    "dev": true,
+                    "optional": true
+                },
+                "glob-parent": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+                    "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "is-glob": "^3.1.0",
+                        "path-dirname": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "is-glob": {
+                            "version": "3.1.0",
+                            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                            "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "is-extglob": "^2.1.0"
+                            }
+                        }
+                    }
+                },
+                "is-binary-path": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+                    "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "binary-extensions": "^1.0.0"
+                    }
+                },
+                "is-extglob": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+                    "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+                    "dev": true,
+                    "optional": true
+                },
+                "is-glob": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+                    "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "is-extglob": "^2.1.1"
+                    }
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    }
+                },
+                "readdirp": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+                    "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.11",
+                        "micromatch": "^3.1.10",
+                        "readable-stream": "^2.0.2"
+                    }
+                }
             }
         },
         "@nodelib/fs.scandir": {
@@ -1886,20 +2240,38 @@
                 "react-lifecycles-compat": "^3.0.4"
             }
         },
-        "@storybook/addon-a11y": {
-            "version": "6.0.26",
-            "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-6.0.26.tgz",
-            "integrity": "sha512-sx1Ethl9W3Kfns0qB1v0CoAymKTC+odB+rCjUKM1h/ILS/n8ZzwkzAj0L7DU/6wA0nZwZDQ+1wL2ZN7r+vxr8A==",
+        "@sinonjs/commons": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+            "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
             "dev": true,
             "requires": {
-                "@storybook/addons": "6.0.26",
-                "@storybook/api": "6.0.26",
-                "@storybook/channels": "6.0.26",
-                "@storybook/client-api": "6.0.26",
-                "@storybook/client-logger": "6.0.26",
-                "@storybook/components": "6.0.26",
-                "@storybook/core-events": "6.0.26",
-                "@storybook/theming": "6.0.26",
+                "type-detect": "4.0.8"
+            }
+        },
+        "@sinonjs/fake-timers": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+            "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/commons": "^1.7.0"
+            }
+        },
+        "@storybook/addon-a11y": {
+            "version": "6.0.27",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-6.0.27.tgz",
+            "integrity": "sha512-x7b/FjjzRU2fQMs4Ur/nqjIc5lBOEbJi22OQHOLvOlnWRFT+81LUpe13qUC+4QWA6hH2jqFLM/UBRjf1Jil9JA==",
+            "dev": true,
+            "requires": {
+                "@storybook/addons": "6.0.27",
+                "@storybook/api": "6.0.27",
+                "@storybook/channels": "6.0.27",
+                "@storybook/client-api": "6.0.27",
+                "@storybook/client-logger": "6.0.27",
+                "@storybook/components": "6.0.27",
+                "@storybook/core-events": "6.0.27",
+                "@storybook/theming": "6.0.27",
                 "axe-core": "^3.5.2",
                 "core-js": "^3.0.1",
                 "global": "^4.3.2",
@@ -1911,17 +2283,17 @@
             }
         },
         "@storybook/addon-actions": {
-            "version": "6.0.26",
-            "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-6.0.26.tgz",
-            "integrity": "sha512-9tWbAqSwzWWVz8zwAndZFusZYjIcRYgZUC0LqC8QlH79DgF3ASjw9y97+w1VTTAzdb6LYnsMuSpX6+8m5hrR4g==",
+            "version": "6.0.27",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-6.0.27.tgz",
+            "integrity": "sha512-GtYSjwGeuRSOAVLuSM2Kae5w17aUgKNXzy1zrWlXlBpTrcyhciRsRBSMGV3PV3EpF3HpxQfyWmJZa3OgFsXdRw==",
             "dev": true,
             "requires": {
-                "@storybook/addons": "6.0.26",
-                "@storybook/api": "6.0.26",
-                "@storybook/client-api": "6.0.26",
-                "@storybook/components": "6.0.26",
-                "@storybook/core-events": "6.0.26",
-                "@storybook/theming": "6.0.26",
+                "@storybook/addons": "6.0.27",
+                "@storybook/api": "6.0.27",
+                "@storybook/client-api": "6.0.27",
+                "@storybook/components": "6.0.27",
+                "@storybook/core-events": "6.0.27",
+                "@storybook/theming": "6.0.27",
                 "core-js": "^3.0.1",
                 "fast-deep-equal": "^3.1.1",
                 "global": "^4.3.2",
@@ -1945,17 +2317,17 @@
             }
         },
         "@storybook/addon-backgrounds": {
-            "version": "6.0.26",
-            "resolved": "https://registry.npmjs.org/@storybook/addon-backgrounds/-/addon-backgrounds-6.0.26.tgz",
-            "integrity": "sha512-Y9t1s4N2PgTxLhO85w+WFnnclZNRdxGpsoiLDPkb63HajZvUa5/ogmIOrfFl5DX2zCpkgNLlskmDcEP6n835cA==",
+            "version": "6.0.27",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-backgrounds/-/addon-backgrounds-6.0.27.tgz",
+            "integrity": "sha512-TO7+ip7KzcADftuH+BFfH8aWVHfHs50Cl4/02uv8AQ/mLZFmb/HkuGDBfRwCv4fWclX613mmL9P0M4sbpYUlGw==",
             "dev": true,
             "requires": {
-                "@storybook/addons": "6.0.26",
-                "@storybook/api": "6.0.26",
-                "@storybook/client-logger": "6.0.26",
-                "@storybook/components": "6.0.26",
-                "@storybook/core-events": "6.0.26",
-                "@storybook/theming": "6.0.26",
+                "@storybook/addons": "6.0.27",
+                "@storybook/api": "6.0.27",
+                "@storybook/client-logger": "6.0.27",
+                "@storybook/components": "6.0.27",
+                "@storybook/core-events": "6.0.27",
+                "@storybook/theming": "6.0.27",
                 "core-js": "^3.0.1",
                 "memoizerific": "^1.11.3",
                 "react": "^16.8.3",
@@ -1963,25 +2335,25 @@
             }
         },
         "@storybook/addon-controls": {
-            "version": "6.0.26",
-            "resolved": "https://registry.npmjs.org/@storybook/addon-controls/-/addon-controls-6.0.26.tgz",
-            "integrity": "sha512-K3Oik9ClpShv8Qc6JeNwtmd4yJJcnO2nyaAYYFiyNt+Vsg7zMaDtE2wfvViThNKjX7nUXIeh+OscseIkdWgLuA==",
+            "version": "6.0.27",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-controls/-/addon-controls-6.0.27.tgz",
+            "integrity": "sha512-YdAwizkDJKo+TpsBB4nnorZZuSdl7+lI0kD7CUUicDdcTAQdI/mNUvKOCKVWAnYLzQmdWRc3e3GNvp003Q155g==",
             "dev": true,
             "requires": {
-                "@storybook/addons": "6.0.26",
-                "@storybook/api": "6.0.26",
-                "@storybook/client-api": "6.0.26",
-                "@storybook/components": "6.0.26",
-                "@storybook/node-logger": "6.0.26",
-                "@storybook/theming": "6.0.26",
+                "@storybook/addons": "6.0.27",
+                "@storybook/api": "6.0.27",
+                "@storybook/client-api": "6.0.27",
+                "@storybook/components": "6.0.27",
+                "@storybook/node-logger": "6.0.27",
+                "@storybook/theming": "6.0.27",
                 "core-js": "^3.0.1",
                 "ts-dedent": "^1.1.1"
             }
         },
         "@storybook/addon-docs": {
-            "version": "6.0.26",
-            "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-6.0.26.tgz",
-            "integrity": "sha512-3t8AOPkp8ZW74h7FnzxF3wAeb1wRyYjMmgJZxqzgi/x7K0i1inbCq8MuJnytuTcZ7+EK4HR6Ih7o9tJuAtIBLw==",
+            "version": "6.0.27",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-6.0.27.tgz",
+            "integrity": "sha512-NXSNulvpH2CL/aPPVa/llVc7SFOZUMkECcVmNf3aO0inE3nn2QN1dW3LfJaESuZYwLKFRa7qY+0CmvNqOrHXrQ==",
             "dev": true,
             "requires": {
                 "@babel/generator": "^7.9.6",
@@ -1992,18 +2364,18 @@
                 "@mdx-js/loader": "^1.5.1",
                 "@mdx-js/mdx": "^1.5.1",
                 "@mdx-js/react": "^1.5.1",
-                "@storybook/addons": "6.0.26",
-                "@storybook/api": "6.0.26",
-                "@storybook/client-api": "6.0.26",
-                "@storybook/client-logger": "6.0.26",
-                "@storybook/components": "6.0.26",
-                "@storybook/core": "6.0.26",
-                "@storybook/core-events": "6.0.26",
+                "@storybook/addons": "6.0.27",
+                "@storybook/api": "6.0.27",
+                "@storybook/client-api": "6.0.27",
+                "@storybook/client-logger": "6.0.27",
+                "@storybook/components": "6.0.27",
+                "@storybook/core": "6.0.27",
+                "@storybook/core-events": "6.0.27",
                 "@storybook/csf": "0.0.1",
-                "@storybook/node-logger": "6.0.26",
-                "@storybook/postinstall": "6.0.26",
-                "@storybook/source-loader": "6.0.26",
-                "@storybook/theming": "6.0.26",
+                "@storybook/node-logger": "6.0.27",
+                "@storybook/postinstall": "6.0.27",
+                "@storybook/source-loader": "6.0.27",
+                "@storybook/theming": "6.0.27",
                 "acorn": "^7.1.0",
                 "acorn-jsx": "^5.1.0",
                 "acorn-walk": "^7.0.0",
@@ -2022,21 +2394,29 @@
                 "remark-slug": "^6.0.0",
                 "ts-dedent": "^1.1.1",
                 "util-deprecate": "^1.0.2"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "7.4.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+                    "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+                    "dev": true
+                }
             }
         },
         "@storybook/addon-knobs": {
-            "version": "6.0.26",
-            "resolved": "https://registry.npmjs.org/@storybook/addon-knobs/-/addon-knobs-6.0.26.tgz",
-            "integrity": "sha512-a25hOepctnsqX1nym80HLKrn8fvXFqsbcL3ZkAZWAIXZhf+zPYTJFrw25FxvbyhktmjQv6l89jteAfGfC0g8DA==",
+            "version": "6.0.27",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-knobs/-/addon-knobs-6.0.27.tgz",
+            "integrity": "sha512-92vAznRPWJHRt2SP408S/UVTk7/wfPmgWLvdAP7fZ0JO/ysrDHYxqgCly3fuDA6YBCdhBk4aL8ICXfrmy7bE4w==",
             "dev": true,
             "requires": {
-                "@storybook/addons": "6.0.26",
-                "@storybook/api": "6.0.26",
-                "@storybook/channels": "6.0.26",
-                "@storybook/client-api": "6.0.26",
-                "@storybook/components": "6.0.26",
-                "@storybook/core-events": "6.0.26",
-                "@storybook/theming": "6.0.26",
+                "@storybook/addons": "6.0.27",
+                "@storybook/api": "6.0.27",
+                "@storybook/channels": "6.0.27",
+                "@storybook/client-api": "6.0.27",
+                "@storybook/components": "6.0.27",
+                "@storybook/core-events": "6.0.27",
+                "@storybook/theming": "6.0.27",
                 "copy-to-clipboard": "^3.0.8",
                 "core-js": "^3.0.1",
                 "escape-html": "^1.0.3",
@@ -2052,16 +2432,16 @@
             }
         },
         "@storybook/addon-links": {
-            "version": "6.0.26",
-            "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-6.0.26.tgz",
-            "integrity": "sha512-yHC6gSMW6qLqikf9yF62tXvykwCDLZy/7SRW9PEAsQcz27bilTh5swoV4HK24Gb6d+TAR+8sJK+BXuFlKFJE+Q==",
+            "version": "6.0.27",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-6.0.27.tgz",
+            "integrity": "sha512-3jgGy+wgeJuqrdOPQCIOTk8TBtFGGoAbzahnuDjh4eH34uSAZgVurME3ojdnqq743ELzMZXL78Y46otZOzVnkA==",
             "dev": true,
             "requires": {
-                "@storybook/addons": "6.0.26",
-                "@storybook/client-logger": "6.0.26",
-                "@storybook/core-events": "6.0.26",
+                "@storybook/addons": "6.0.27",
+                "@storybook/client-logger": "6.0.27",
+                "@storybook/core-events": "6.0.27",
                 "@storybook/csf": "0.0.1",
-                "@storybook/router": "6.0.26",
+                "@storybook/router": "6.0.27",
                 "@types/qs": "^6.9.0",
                 "core-js": "^3.0.1",
                 "global": "^4.3.2",
@@ -2072,30 +2452,30 @@
             }
         },
         "@storybook/addon-toolbars": {
-            "version": "6.0.26",
-            "resolved": "https://registry.npmjs.org/@storybook/addon-toolbars/-/addon-toolbars-6.0.26.tgz",
-            "integrity": "sha512-f9OI7ix0lQWg4eEHheWYB3dz7kYO6qCGkzp+oIQkPpjnYmY8ZghyRM+ui6vfq+G8BwxrAKGR0CB8ttNxVsd/9A==",
+            "version": "6.0.27",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-toolbars/-/addon-toolbars-6.0.27.tgz",
+            "integrity": "sha512-Ak0srUPOX9m44UfQwZK4ue1hCNvkhfhB5PfVwjN6KyglpRCCNdFIT3BIPshmPXSyO1eeRL4rufxWtvtcqCodag==",
             "dev": true,
             "requires": {
-                "@storybook/addons": "6.0.26",
-                "@storybook/api": "6.0.26",
-                "@storybook/client-api": "6.0.26",
-                "@storybook/components": "6.0.26",
+                "@storybook/addons": "6.0.27",
+                "@storybook/api": "6.0.27",
+                "@storybook/client-api": "6.0.27",
+                "@storybook/components": "6.0.27",
                 "core-js": "^3.0.1"
             }
         },
         "@storybook/addon-viewport": {
-            "version": "6.0.26",
-            "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-6.0.26.tgz",
-            "integrity": "sha512-LdVW61iZhUf2npNk3qPH9DTunVMhKcyiFq2CRlgxcA5FwjdkAbcPiYMc18rfyTvp/Zd2idartvwYalBYpJhAhw==",
+            "version": "6.0.27",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-6.0.27.tgz",
+            "integrity": "sha512-oSHJeWsWr21UIxp5yU+aTpegBLBphz1Vx49t1v3uqxTWZaUAWtXTbdZxkvTd4kkEDzEEyUa4Vj8UoXPMTpYBAA==",
             "dev": true,
             "requires": {
-                "@storybook/addons": "6.0.26",
-                "@storybook/api": "6.0.26",
-                "@storybook/client-logger": "6.0.26",
-                "@storybook/components": "6.0.26",
-                "@storybook/core-events": "6.0.26",
-                "@storybook/theming": "6.0.26",
+                "@storybook/addons": "6.0.27",
+                "@storybook/api": "6.0.27",
+                "@storybook/client-logger": "6.0.27",
+                "@storybook/components": "6.0.27",
+                "@storybook/core-events": "6.0.27",
+                "@storybook/theming": "6.0.27",
                 "core-js": "^3.0.1",
                 "global": "^4.3.2",
                 "memoizerific": "^1.11.3",
@@ -2104,34 +2484,34 @@
             }
         },
         "@storybook/addons": {
-            "version": "6.0.26",
-            "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.0.26.tgz",
-            "integrity": "sha512-OhAApFKgsj9an7FLYfHI4cJQuZ4Zm6yoGOpaxhOvKQMw7dXUPsLvbCyw/6dZOLvaFhjJjQiXtbxtZG+UjR8nvA==",
+            "version": "6.0.27",
+            "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.0.27.tgz",
+            "integrity": "sha512-ruumzJ1BLQ/2+KbV6qTN1OWPqejPWczY2EjEKo8azMlmZ4xBSiczi5HvDto/fYt6fMQfzgkdIUAcofHGf4XQGQ==",
             "requires": {
-                "@storybook/api": "6.0.26",
-                "@storybook/channels": "6.0.26",
-                "@storybook/client-logger": "6.0.26",
-                "@storybook/core-events": "6.0.26",
-                "@storybook/router": "6.0.26",
-                "@storybook/theming": "6.0.26",
+                "@storybook/api": "6.0.27",
+                "@storybook/channels": "6.0.27",
+                "@storybook/client-logger": "6.0.27",
+                "@storybook/core-events": "6.0.27",
+                "@storybook/router": "6.0.27",
+                "@storybook/theming": "6.0.27",
                 "core-js": "^3.0.1",
                 "global": "^4.3.2",
                 "regenerator-runtime": "^0.13.3"
             }
         },
         "@storybook/api": {
-            "version": "6.0.26",
-            "resolved": "https://registry.npmjs.org/@storybook/api/-/api-6.0.26.tgz",
-            "integrity": "sha512-aszDoz1c6T+eRtTUwWvySoyd3gRXmQxsingD084NnEp4VfFLA5H7VS/0sre0ZvU5GWh8d9COxY0DS2Ry/QSKvw==",
+            "version": "6.0.27",
+            "resolved": "https://registry.npmjs.org/@storybook/api/-/api-6.0.27.tgz",
+            "integrity": "sha512-48LDFK+mOdPBHjZWYTOLZnOJ3XPn8OxJm7h5dCuuFe6wblQIYxXeyBwn6BVOkmonmNJ9OglUGY7KqslaOrGYyQ==",
             "requires": {
                 "@reach/router": "^1.3.3",
-                "@storybook/channels": "6.0.26",
-                "@storybook/client-logger": "6.0.26",
-                "@storybook/core-events": "6.0.26",
+                "@storybook/channels": "6.0.27",
+                "@storybook/client-logger": "6.0.27",
+                "@storybook/core-events": "6.0.27",
                 "@storybook/csf": "0.0.1",
-                "@storybook/router": "6.0.26",
+                "@storybook/router": "6.0.27",
                 "@storybook/semver": "^7.3.2",
-                "@storybook/theming": "6.0.26",
+                "@storybook/theming": "6.0.27",
                 "@types/reach__router": "^1.3.5",
                 "core-js": "^3.0.1",
                 "fast-deep-equal": "^3.1.1",
@@ -2147,13 +2527,13 @@
             }
         },
         "@storybook/channel-postmessage": {
-            "version": "6.0.26",
-            "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-6.0.26.tgz",
-            "integrity": "sha512-FT6lC8M5JlNBxPT0rYfmF1yl9mBv04nfYs82TZpp1CzpLxf7wxdCBZ8SSRmvWIVBoNwGZPDhIk5+6JWyDEISBg==",
+            "version": "6.0.27",
+            "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-6.0.27.tgz",
+            "integrity": "sha512-ygLbzJ/WbllPL4albJUSRoiRC3M+Q/stq66PWkLBlb1NhoXanPbmLBFaAiGsypXyH/E9Z6bQT88eUyzM5IlTmw==",
             "requires": {
-                "@storybook/channels": "6.0.26",
-                "@storybook/client-logger": "6.0.26",
-                "@storybook/core-events": "6.0.26",
+                "@storybook/channels": "6.0.27",
+                "@storybook/client-logger": "6.0.27",
+                "@storybook/core-events": "6.0.27",
                 "core-js": "^3.0.1",
                 "global": "^4.3.2",
                 "qs": "^6.6.0",
@@ -2161,9 +2541,9 @@
             }
         },
         "@storybook/channels": {
-            "version": "6.0.26",
-            "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.0.26.tgz",
-            "integrity": "sha512-H0iUorayYqS+zfhbjd+cYRzAdRLGLWUeWFu2Aa+oJ4/zeAQNL+DafWboHc567RQ4Vb5KqE5QZoCFskWUUYqJYA==",
+            "version": "6.0.27",
+            "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.0.27.tgz",
+            "integrity": "sha512-W47tQO/1oAUDEb51URIsodT/G0QPkzpPVy+Q3bJ9buJ9TLIO/qObAH9pYw9ggUOgIJmHJY54I1KN7QAvhuVCfw==",
             "requires": {
                 "core-js": "^3.0.1",
                 "ts-dedent": "^1.1.1",
@@ -2171,15 +2551,15 @@
             }
         },
         "@storybook/client-api": {
-            "version": "6.0.26",
-            "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-6.0.26.tgz",
-            "integrity": "sha512-Qd5wR5b5lio/EchuJMhAmmJAE1pfvnEyu+JnyFGwMZLV9mN9NSspz+YsqbSCCDZsYcP5ewvPEnumIWqmj/wagQ==",
+            "version": "6.0.27",
+            "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-6.0.27.tgz",
+            "integrity": "sha512-4AaBZCds2dr4JVVlOVa2LF3Vjv0VcLVWaqibydPRO6Ch2shDw2ImwQxYBEq0WygfHR7VzG1cmOK8D92C7goPKA==",
             "requires": {
-                "@storybook/addons": "6.0.26",
-                "@storybook/channel-postmessage": "6.0.26",
-                "@storybook/channels": "6.0.26",
-                "@storybook/client-logger": "6.0.26",
-                "@storybook/core-events": "6.0.26",
+                "@storybook/addons": "6.0.27",
+                "@storybook/channel-postmessage": "6.0.27",
+                "@storybook/channels": "6.0.27",
+                "@storybook/client-logger": "6.0.27",
+                "@storybook/core-events": "6.0.27",
                 "@storybook/csf": "0.0.1",
                 "@types/qs": "^6.9.0",
                 "@types/webpack-env": "^1.15.2",
@@ -2195,22 +2575,22 @@
             }
         },
         "@storybook/client-logger": {
-            "version": "6.0.26",
-            "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.0.26.tgz",
-            "integrity": "sha512-VNoL6/oehVhn3hZi9vrTNT+C/3oAZKV+smfZFnPtsCR/Fq7CKbmsBd0pGPL57f81RU8e8WygwrIlAGJTDSNIjw==",
+            "version": "6.0.27",
+            "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.0.27.tgz",
+            "integrity": "sha512-IY/p0f9XxfHZWVkjeIYOwF6xuonjgmZ9mYPy7Ks47zzDFrUe0/g5cqfBJBUj1YOqlANbF6XCO8YiKXjkE70olw==",
             "requires": {
                 "core-js": "^3.0.1",
                 "global": "^4.3.2"
             }
         },
         "@storybook/components": {
-            "version": "6.0.26",
-            "resolved": "https://registry.npmjs.org/@storybook/components/-/components-6.0.26.tgz",
-            "integrity": "sha512-8wigI1pDFJO1m1IQWPguOK+nOsaAVRWkVdu+2te/rDcIR9QNvMzzou0+Lhfp3zKSVT4E6mEoGB/TWXXF5Iq0sQ==",
+            "version": "6.0.27",
+            "resolved": "https://registry.npmjs.org/@storybook/components/-/components-6.0.27.tgz",
+            "integrity": "sha512-CnWgr/jgo7/XU+s7jhpNYevUivEsJccMRxuyOI+Ry8ndnoheifT4fp4+O5OaOeC08hStlPyad85LdTbOKigt7g==",
             "requires": {
-                "@storybook/client-logger": "6.0.26",
+                "@storybook/client-logger": "6.0.27",
                 "@storybook/csf": "0.0.1",
-                "@storybook/theming": "6.0.26",
+                "@storybook/theming": "6.0.27",
                 "@types/overlayscrollbars": "^1.9.0",
                 "@types/react-color": "^3.0.1",
                 "@types/react-syntax-highlighter": "11.0.4",
@@ -2233,9 +2613,9 @@
             }
         },
         "@storybook/core": {
-            "version": "6.0.26",
-            "resolved": "https://registry.npmjs.org/@storybook/core/-/core-6.0.26.tgz",
-            "integrity": "sha512-2kmkxbzDJVrjzCjlseffoQJwZRH9bHZUumo5m8gpbN9kVnADER7yd6RUf2Zle5BK3ExC+0PPI1Whfg0qkiXvqw==",
+            "version": "6.0.27",
+            "resolved": "https://registry.npmjs.org/@storybook/core/-/core-6.0.27.tgz",
+            "integrity": "sha512-qHONOXU8g17IfSaMF0HaSQfUFUGqOIBCX6g5qNHuzuASNsrdDmSr6xgF9+htltaQjSpC+s/4zOpn7kXfh1+eGQ==",
             "requires": {
                 "@babel/plugin-proposal-class-properties": "^7.8.3",
                 "@babel/plugin-proposal-decorators": "^7.8.3",
@@ -2258,20 +2638,20 @@
                 "@babel/preset-react": "^7.8.3",
                 "@babel/preset-typescript": "^7.9.0",
                 "@babel/register": "^7.10.5",
-                "@storybook/addons": "6.0.26",
-                "@storybook/api": "6.0.26",
-                "@storybook/channel-postmessage": "6.0.26",
-                "@storybook/channels": "6.0.26",
-                "@storybook/client-api": "6.0.26",
-                "@storybook/client-logger": "6.0.26",
-                "@storybook/components": "6.0.26",
-                "@storybook/core-events": "6.0.26",
+                "@storybook/addons": "6.0.27",
+                "@storybook/api": "6.0.27",
+                "@storybook/channel-postmessage": "6.0.27",
+                "@storybook/channels": "6.0.27",
+                "@storybook/client-api": "6.0.27",
+                "@storybook/client-logger": "6.0.27",
+                "@storybook/components": "6.0.27",
+                "@storybook/core-events": "6.0.27",
                 "@storybook/csf": "0.0.1",
-                "@storybook/node-logger": "6.0.26",
-                "@storybook/router": "6.0.26",
+                "@storybook/node-logger": "6.0.27",
+                "@storybook/router": "6.0.27",
                 "@storybook/semver": "^7.3.2",
-                "@storybook/theming": "6.0.26",
-                "@storybook/ui": "6.0.26",
+                "@storybook/theming": "6.0.27",
+                "@storybook/ui": "6.0.27",
                 "@types/glob-base": "^0.3.0",
                 "@types/micromatch": "^4.0.1",
                 "@types/node-fetch": "^2.5.4",
@@ -2382,9 +2762,9 @@
             }
         },
         "@storybook/core-events": {
-            "version": "6.0.26",
-            "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.0.26.tgz",
-            "integrity": "sha512-nWjS/+kMiw31OPgeJQaiFsJk9ZJJo3/d4c+kc6GOl2iC1H3Q4/5cm3NvJBn/7bUtKHmSFwfbDouj+XjUk5rZbQ==",
+            "version": "6.0.27",
+            "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.0.27.tgz",
+            "integrity": "sha512-w+Q2pt7DyhonWhHqjeBMMHMtV8h07ROOF9P40RthepT6/GO/471X33cgngr0i0uPgqha3JajNIl9fwAybsIROw==",
             "requires": {
                 "core-js": "^3.0.1"
             }
@@ -2398,9 +2778,9 @@
             }
         },
         "@storybook/node-logger": {
-            "version": "6.0.26",
-            "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-6.0.26.tgz",
-            "integrity": "sha512-mdILu91d/2ZgYfICoAMBjwBAYOgjk2URsPudrs5+23lFoPPIwf4CPWcfgs0f4GdfoICk3kV0W7+8bIARhRKp3g==",
+            "version": "6.0.27",
+            "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-6.0.27.tgz",
+            "integrity": "sha512-HlVWi2EvWPAOS19BctlhDZ989oBd7MvFbkgr2xTs01UhH96DcsUXCeMwQGhw1D5wgvpi7JtM4Y830BsBBiBLJQ==",
             "requires": {
                 "@types/npmlog": "^4.1.2",
                 "chalk": "^4.0.0",
@@ -2455,30 +2835,30 @@
             }
         },
         "@storybook/postinstall": {
-            "version": "6.0.26",
-            "resolved": "https://registry.npmjs.org/@storybook/postinstall/-/postinstall-6.0.26.tgz",
-            "integrity": "sha512-B9Dh66MfserWw1J4KbLqfxpnanN//yeDjrrkowzqa3OFLqEPQCekv0ALocovnCkQ13+TcVGjPprxnWXfGhEMpg==",
+            "version": "6.0.27",
+            "resolved": "https://registry.npmjs.org/@storybook/postinstall/-/postinstall-6.0.27.tgz",
+            "integrity": "sha512-GgrBCuOQKhlM3+X+bVCdoQqCofzfwCQS+21VgAfJ8bFeCHT8n6kY48OTf+vr6uosjSuQ7sJCiHWvosk3OqBsXA==",
             "dev": true,
             "requires": {
                 "core-js": "^3.0.1"
             }
         },
         "@storybook/react": {
-            "version": "6.0.26",
-            "resolved": "https://registry.npmjs.org/@storybook/react/-/react-6.0.26.tgz",
-            "integrity": "sha512-X02VpIEhpVc4avYiff861c015++tvMVSXJSrDP5J1xTAglVEiRFcU0Kn5h96o9N8FTup2n2xyj6Y7e8oC9yLXQ==",
+            "version": "6.0.27",
+            "resolved": "https://registry.npmjs.org/@storybook/react/-/react-6.0.27.tgz",
+            "integrity": "sha512-otIWq00UR7vfE4eeX9TIlgXy+UmaRitzqLRaFwdJCHUUWp9GZRrTcQLphJ5bl2tRO3GuzA/YO8VtJLGpCnkGXg==",
             "requires": {
                 "@babel/preset-flow": "^7.0.0",
                 "@babel/preset-react": "^7.0.0",
-                "@storybook/addons": "6.0.26",
-                "@storybook/core": "6.0.26",
-                "@storybook/node-logger": "6.0.26",
+                "@storybook/addons": "6.0.27",
+                "@storybook/core": "6.0.27",
+                "@storybook/node-logger": "6.0.27",
                 "@storybook/semver": "^7.3.2",
                 "@svgr/webpack": "^5.4.0",
                 "@types/webpack-env": "^1.15.2",
                 "babel-plugin-add-react-displayname": "^0.0.5",
                 "babel-plugin-named-asset-import": "^0.3.1",
-                "babel-plugin-react-docgen": "^4.1.0",
+                "babel-plugin-react-docgen": "^4.2.1",
                 "core-js": "^3.0.1",
                 "global": "^4.3.2",
                 "lodash": "^4.17.15",
@@ -2491,9 +2871,9 @@
             }
         },
         "@storybook/router": {
-            "version": "6.0.26",
-            "resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.0.26.tgz",
-            "integrity": "sha512-kQ1LF/2gX3IkjS1wX7CsoeBc9ptHQzOsyax16rUyJa769DT5vMNtFtQxjNXMqSiSapPg2yrXJFKQNaoWvKgQEQ==",
+            "version": "6.0.27",
+            "resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.0.27.tgz",
+            "integrity": "sha512-jo6d48mZLeHyv8wYf0NnV0eCtJ7LRsBaf1x2c967u4GAQ128+bYXm0iZwAtv4kYmH3YgETGuCbKpZyQbjbhUVQ==",
             "requires": {
                 "@reach/router": "^1.3.3",
                 "@types/reach__router": "^1.3.5",
@@ -2513,13 +2893,13 @@
             }
         },
         "@storybook/source-loader": {
-            "version": "6.0.26",
-            "resolved": "https://registry.npmjs.org/@storybook/source-loader/-/source-loader-6.0.26.tgz",
-            "integrity": "sha512-axNYEHEj7c9oHUFTMKZ6xRyKZCEEP7Aa9sFPzV5Q3Vrq6/3qhih5fOPXhst6/s4XZC1eIoKKHb/Gk4hmjYOEYA==",
+            "version": "6.0.27",
+            "resolved": "https://registry.npmjs.org/@storybook/source-loader/-/source-loader-6.0.27.tgz",
+            "integrity": "sha512-mLncCAN0s9mcUY7/wFAwJvXDV2ts5XxB40ZHRZKlseTiI011uwf1AEBOmeSWft/CxOtbicHTYbIHdMokuWNjmg==",
             "dev": true,
             "requires": {
-                "@storybook/addons": "6.0.26",
-                "@storybook/client-logger": "6.0.26",
+                "@storybook/addons": "6.0.27",
+                "@storybook/client-logger": "6.0.27",
                 "@storybook/csf": "0.0.1",
                 "core-js": "^3.0.1",
                 "estraverse": "^4.2.0",
@@ -2530,6 +2910,17 @@
                 "regenerator-runtime": "^0.13.3"
             },
             "dependencies": {
+                "loader-utils": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+                    "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+                    "dev": true,
+                    "requires": {
+                        "big.js": "^5.2.2",
+                        "emojis-list": "^3.0.0",
+                        "json5": "^2.1.2"
+                    }
+                },
                 "prettier": {
                     "version": "2.0.5",
                     "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
@@ -2539,14 +2930,14 @@
             }
         },
         "@storybook/theming": {
-            "version": "6.0.26",
-            "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.0.26.tgz",
-            "integrity": "sha512-9yon2ofb9a+RT1pdvn8Njydy7XRw0qXcIsMqGsJRKoZecmRRozqB6DxH9Gbdf1vRSbM9gYUUDjbiMDFz7+4RiQ==",
+            "version": "6.0.27",
+            "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.0.27.tgz",
+            "integrity": "sha512-6jm7tJuGUZzSftRQce776fS9/Pt5OAypmaTOj035z3RWswoQ1pj8olXVnSNxSt6jyYoWrJru8kiCl7w78q0rPg==",
             "requires": {
                 "@emotion/core": "^10.0.20",
                 "@emotion/is-prop-valid": "^0.8.6",
                 "@emotion/styled": "^10.0.17",
-                "@storybook/client-logger": "6.0.26",
+                "@storybook/client-logger": "6.0.27",
                 "core-js": "^3.0.1",
                 "deep-object-diff": "^1.1.0",
                 "emotion-theming": "^10.0.19",
@@ -2558,20 +2949,20 @@
             }
         },
         "@storybook/ui": {
-            "version": "6.0.26",
-            "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-6.0.26.tgz",
-            "integrity": "sha512-Jb7oUJs6uyW+rM4zA8xDn9T0/0XtUAOC/zBl6ofdhYU9rVjYKAQUJqmYgUHNOggq1NGS7BVp1RJIzDWGYEagsA==",
+            "version": "6.0.27",
+            "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-6.0.27.tgz",
+            "integrity": "sha512-hxTeoe3QTSJ4P9EI8Kc8hroxem5OXEYq77zKq8XxgtOKhVzhQVaA+c4p/t6Z68+yK693CCp07+6QvGo++EQEHw==",
             "requires": {
                 "@emotion/core": "^10.0.20",
-                "@storybook/addons": "6.0.26",
-                "@storybook/api": "6.0.26",
-                "@storybook/channels": "6.0.26",
-                "@storybook/client-logger": "6.0.26",
-                "@storybook/components": "6.0.26",
-                "@storybook/core-events": "6.0.26",
-                "@storybook/router": "6.0.26",
+                "@storybook/addons": "6.0.27",
+                "@storybook/api": "6.0.27",
+                "@storybook/channels": "6.0.27",
+                "@storybook/client-logger": "6.0.27",
+                "@storybook/components": "6.0.27",
+                "@storybook/core-events": "6.0.27",
+                "@storybook/router": "6.0.27",
                 "@storybook/semver": "^7.3.2",
-                "@storybook/theming": "6.0.26",
+                "@storybook/theming": "6.0.27",
                 "@types/markdown-to-jsx": "^6.11.0",
                 "copy-to-clipboard": "^3.0.8",
                 "core-js": "^3.0.1",
@@ -2696,9 +3087,9 @@
             }
         },
         "@styled-icons/fa-brands": {
-            "version": "10.18.0",
-            "resolved": "https://registry.npmjs.org/@styled-icons/fa-brands/-/fa-brands-10.18.0.tgz",
-            "integrity": "sha512-bYMT+3/GNcE0MR7pZVXn0CyWQRrijjQSXFaqlPG5qhT0Z8wwNYIgxTqfEPnQoxreheHgZ6rkAc/kl2Dxl98jzQ==",
+            "version": "10.22.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/fa-brands/-/fa-brands-10.22.0.tgz",
+            "integrity": "sha512-2nVy0/eSAETvqOdj6POmztAwbMLKnczpTMKJupk5xtRxebFValu9gL4lhA3G4BfrUFgexFEeh/2r9/3vmJjJ5A==",
             "dev": true,
             "requires": {
                 "@babel/runtime": "^7.10.5",
@@ -2706,9 +3097,9 @@
             }
         },
         "@styled-icons/fa-regular": {
-            "version": "10.18.0",
-            "resolved": "https://registry.npmjs.org/@styled-icons/fa-regular/-/fa-regular-10.18.0.tgz",
-            "integrity": "sha512-nh027K1OhKXDnWsRY/KRs5oWhgkc3uf66OoluzXWgRpxOD6JBYbdWA8bXgx5sk4LQiGnNGVDFI8X8mnv57wwcg==",
+            "version": "10.22.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/fa-regular/-/fa-regular-10.22.0.tgz",
+            "integrity": "sha512-R8/BpFeRVgid3arIQkywqz5mrRNafUJ1CTAj4flhKBPAXYw+eTwOZipwbYxTxA4/OrPyn7PT0jG/P1KxrqLROw==",
             "dev": true,
             "requires": {
                 "@babel/runtime": "^7.10.5",
@@ -2716,9 +3107,9 @@
             }
         },
         "@styled-icons/fa-solid": {
-            "version": "10.18.0",
-            "resolved": "https://registry.npmjs.org/@styled-icons/fa-solid/-/fa-solid-10.18.0.tgz",
-            "integrity": "sha512-lpBXAwymZiVbfwnUyKXgRL/qcc1VUUYJ6wOJueg6NyDOggvpTMhjlRs0mMF+9Zn/NhtCOrDf2tAW653smH11KQ==",
+            "version": "10.22.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/fa-solid/-/fa-solid-10.22.0.tgz",
+            "integrity": "sha512-3aaX9Mu6J0W/Oh8jYFGe2bmoc9/sLYYhFHmrSHdRMZ4YdZ5xu6lJO9Aygi0aUjAhXkgJ31+goHL9QIrZ78lWdw==",
             "dev": true,
             "requires": {
                 "@babel/runtime": "^7.10.5",
@@ -2896,9 +3287,9 @@
             }
         },
         "@styled-icons/simple-icons": {
-            "version": "10.21.0",
-            "resolved": "https://registry.npmjs.org/@styled-icons/simple-icons/-/simple-icons-10.21.0.tgz",
-            "integrity": "sha512-fbd+KMETkBw/ZeSf0KyRdLpwRqpcSSJWhv5dLnZnDlj+a1aIRDZZl+eQ2BBgPJYzdXIx4fYP+l3kGugNPy1eyA==",
+            "version": "10.22.0",
+            "resolved": "https://registry.npmjs.org/@styled-icons/simple-icons/-/simple-icons-10.22.0.tgz",
+            "integrity": "sha512-DEsCk9TsW0z4GWdfiuOGkAIU9WzYIfZ7uT7WOoqYeTZe90Fj6FWirIZUWbo2ON0ZMfjmyf6W2hHAJSIiWBRLaA==",
             "dev": true,
             "requires": {
                 "@babel/runtime": "^7.10.5",
@@ -3001,9 +3392,9 @@
             },
             "dependencies": {
                 "camelcase": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
-                    "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w=="
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.1.0.tgz",
+                    "integrity": "sha512-WCMml9ivU60+8rEJgELlFp1gxFcEGxwYleE3bziHEDeqsqAWGHdimB7beBFGjLzVNgPGyDsfgXLQEYMpmIFnVQ=="
                 }
             }
         },
@@ -3049,6 +3440,18 @@
                 "@svgr/plugin-jsx": "^5.4.0",
                 "@svgr/plugin-svgo": "^5.4.0",
                 "loader-utils": "^2.0.0"
+            },
+            "dependencies": {
+                "loader-utils": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+                    "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+                    "requires": {
+                        "big.js": "^5.2.2",
+                        "emojis-list": "^3.0.0",
+                        "json5": "^2.1.2"
+                    }
+                }
             }
         },
         "@types/anymatch": {
@@ -3056,15 +3459,51 @@
             "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
             "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA=="
         },
+        "@types/babel__core": {
+            "version": "7.1.10",
+            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.10.tgz",
+            "integrity": "sha512-x8OM8XzITIMyiwl5Vmo2B1cR1S1Ipkyv4mdlbJjMa1lmuKvKY9FrBbEANIaMlnWn5Rf7uO+rC/VgYabNkE17Hw==",
+            "dev": true,
+            "requires": {
+                "@babel/parser": "^7.1.0",
+                "@babel/types": "^7.0.0",
+                "@types/babel__generator": "*",
+                "@types/babel__template": "*",
+                "@types/babel__traverse": "*"
+            }
+        },
+        "@types/babel__generator": {
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.2.tgz",
+            "integrity": "sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@types/babel__template": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.3.tgz",
+            "integrity": "sha512-uCoznIPDmnickEi6D0v11SBpW0OuVqHJCa7syXqQHy5uktSCreIlt0iglsCnmvz8yCb38hGcWeseA8cWJSwv5Q==",
+            "dev": true,
+            "requires": {
+                "@babel/parser": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@types/babel__traverse": {
+            "version": "7.0.15",
+            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.15.tgz",
+            "integrity": "sha512-Pzh9O3sTK8V6I1olsXpCfj2k/ygO2q1X0vhhnDrEQyYLHZesWz+zMZMVcwXLCYf0U36EtmyYaFGPfXlTtDHe3A==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.3.0"
+            }
+        },
         "@types/braces": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@types/braces/-/braces-3.0.0.tgz",
             "integrity": "sha512-TbH79tcyi9FHwbyboOKeRachRq63mSuWYXOflsNO9ZyE5ClQ/JaozNKl+aWUq87qPNsXasXxi2AbgfwIJ+8GQw=="
-        },
-        "@types/color-name": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-            "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
         },
         "@types/d3-path": {
             "version": "1.0.9",
@@ -3072,9 +3511,9 @@
             "integrity": "sha512-NaIeSIBiFgSC6IGUBjZWcscUJEq7vpVu7KthHN8eieTV9d9MqkSOZLH4chq1PmcKy06PNe3axLeKmRIyxJ+PZQ=="
         },
         "@types/d3-shape": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.3.3.tgz",
-            "integrity": "sha512-kuIftW9veM/8iNY1SvrZOfyJ2+6fFlPhVH7ShKrO3lXCSpe97xor6q89w23Jwir5Gn3xHHR1qS2jF35DstE2Dg==",
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.3.4.tgz",
+            "integrity": "sha512-fxmOjs+UqNQGpztD5BOo+KriE0jLFrBP4Ct++0QExv/xfDOT1cpcMxgsZ+5qPmnR0t+GjbwAe1Um1PHpv3G4oA==",
             "requires": {
                 "@types/d3-path": "^1"
             }
@@ -3102,9 +3541,9 @@
             "integrity": "sha1-pYHWiDR+EOUN18F9byiAoQNUMZ0="
         },
         "@types/graceful-fs": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.3.tgz",
-            "integrity": "sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==",
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.4.tgz",
+            "integrity": "sha512-mWA/4zFQhfvOA8zWkXobwJvBD7vzcxgrOQ0J5CH1votGqdq9m7+FwtGaqyCZqC3NyyBkc9z4m+iry4LlqcMWJg==",
             "dev": true,
             "requires": {
                 "@types/node": "*"
@@ -3167,6 +3606,16 @@
                 "@types/istanbul-lib-report": "*"
             }
         },
+        "@types/jest": {
+            "version": "26.0.15",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.15.tgz",
+            "integrity": "sha512-s2VMReFXRg9XXxV+CW9e5Nz8fH2K1aEhwgjUqPPbQd7g95T0laAcvLv032EhFHIa5GHsZ8W7iJEQVaJq6k3Gog==",
+            "dev": true,
+            "requires": {
+                "jest-diff": "^26.0.0",
+                "pretty-format": "^26.0.0"
+            }
+        },
         "@types/json-schema": {
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
@@ -3209,9 +3658,9 @@
             "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
         },
         "@types/node": {
-            "version": "14.11.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
-            "integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA=="
+            "version": "14.14.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.2.tgz",
+            "integrity": "sha512-jeYJU2kl7hL9U5xuI/BhKPZ4vqGM/OmK6whiFAXVhlstzZhVamWhDSmHyGLIp+RVyuF9/d0dqr2P85aFj4BvJg=="
         },
         "@types/node-fetch": {
             "version": "2.5.7",
@@ -3221,6 +3670,12 @@
                 "@types/node": "*",
                 "form-data": "^3.0.0"
             }
+        },
+        "@types/normalize-package-data": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+            "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+            "dev": true
         },
         "@types/npmlog": {
             "version": "4.1.2",
@@ -3241,6 +3696,12 @@
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-5.0.3.tgz",
             "integrity": "sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==",
+            "dev": true
+        },
+        "@types/prettier": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.5.tgz",
+            "integrity": "sha512-UEyp8LwZ4Dg30kVU2Q3amHHyTn1jEdhCIE59ANed76GaT1Vp76DD3ZWSAxgCrw6wJ0TqeoBpqmfUHiUDPs//HQ==",
             "dev": true
         },
         "@types/prop-types": {
@@ -3268,9 +3729,9 @@
             }
         },
         "@types/react": {
-            "version": "16.9.49",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.49.tgz",
-            "integrity": "sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==",
+            "version": "16.9.53",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.53.tgz",
+            "integrity": "sha512-4nW60Sd4L7+WMXH1D6jCdVftuW7j4Za6zdp6tJ33Rqv0nk1ZAmQKML9ZLD4H0dehA3FZxXR/GM8gXplf82oNGw==",
             "requires": {
                 "@types/prop-types": "*",
                 "csstype": "^3.0.2"
@@ -3310,9 +3771,9 @@
             }
         },
         "@types/react-native": {
-            "version": "0.63.23",
-            "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.63.23.tgz",
-            "integrity": "sha512-4pWQpgyzX+vCEJDceW9Zsc8/SZtJrIUIw9lwYKeTWAtSHWdcRwUns2O/18L98WGo6NUNVdLzY59vOW8ZGWJxSA==",
+            "version": "0.63.30",
+            "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.63.30.tgz",
+            "integrity": "sha512-8/PrOjuUaPTCfMeW12ubseZPUGdbRhxYDa/aT+0D0KWVTe60b4H/gJrcfJmBXC6EcCFcimuTzQCv8/S03slYqA==",
             "requires": {
                 "@types/react": "*"
             }
@@ -3334,11 +3795,11 @@
             }
         },
         "@types/recharts": {
-            "version": "1.8.15",
-            "resolved": "https://registry.npmjs.org/@types/recharts/-/recharts-1.8.15.tgz",
-            "integrity": "sha512-ApCfDT/R8RCbZTcl0iqLiKsxVdzE3GzoawTgJUHuQOz6ZXhsPVfp7CNSKI2s3zFwrRRsgmpv2AEcbcZceNHg4w==",
+            "version": "1.8.16",
+            "resolved": "https://registry.npmjs.org/@types/recharts/-/recharts-1.8.16.tgz",
+            "integrity": "sha512-xBXjOsSJJVP2xGtq/kML4rHGyKxA4x8ZqIU7iwbmWrperpSXzoQ1PWjqf4cBdmcLAWaidDHPJxUVHkZr3R/PEA==",
             "requires": {
-                "@types/d3-shape": "*",
+                "@types/d3-shape": "^1",
                 "@types/react": "*"
             }
         },
@@ -3346,6 +3807,12 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
             "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA=="
+        },
+        "@types/stack-utils": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
+            "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
+            "dev": true
         },
         "@types/storybook__react": {
             "version": "5.2.1",
@@ -3356,9 +3823,9 @@
             }
         },
         "@types/styled-components": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.3.tgz",
-            "integrity": "sha512-HGpirof3WOhiX17lb61Q/tpgqn48jxO8EfZkdJ8ueYqwLbK2AHQe/G08DasdA2IdKnmwOIP1s9X2bopxKXgjRw==",
+            "version": "5.1.4",
+            "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.4.tgz",
+            "integrity": "sha512-78f5Zuy0v/LTQNOYfpH+CINHpchzMMmAt9amY2YNtSgsk1TmlKm8L2Wijss/mtTrsUAVTm2CdGB8VOM65vA8xg==",
             "requires": {
                 "@types/hoist-non-react-statics": "*",
                 "@types/react": "*",
@@ -3393,9 +3860,9 @@
             "dev": true
         },
         "@types/webpack": {
-            "version": "4.41.22",
-            "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.22.tgz",
-            "integrity": "sha512-JQDJK6pj8OMV9gWOnN1dcLCyU9Hzs6lux0wBO4lr1+gyEhIBR9U3FMrz12t2GPkg110XAxEAw2WHF6g7nZIbRQ==",
+            "version": "4.41.23",
+            "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.23.tgz",
+            "integrity": "sha512-ojA4CupZg8RCzVJLugWlvqrHpT59GWhqFxbinlsnvk10MjQCWB+ot7XDACctbWhnhtdhYK7+HOH1JxkVLiZhMg==",
             "requires": {
                 "@types/anymatch": "*",
                 "@types/node": "*",
@@ -3435,9 +3902,9 @@
             }
         },
         "@types/yargs": {
-            "version": "15.0.8",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-            "integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+            "version": "15.0.9",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+            "integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
             "dev": true,
             "requires": {
                 "@types/yargs-parser": "*"
@@ -3450,12 +3917,12 @@
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.3.0.tgz",
-            "integrity": "sha512-RqEcaHuEKnn3oPFislZ6TNzsBLqpZjN93G69SS+laav/I8w/iGMuMq97P0D2/2/kW4SCebHggqhbcCfbDaaX+g==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.5.0.tgz",
+            "integrity": "sha512-mjb/gwNcmDKNt+6mb7Aj/TjKzIJjOPcoCJpjBQC9ZnTRnBt1p4q5dJSSmIqAtsZ/Pff5N+hJlbiPc5bl6QN4OQ==",
             "requires": {
-                "@typescript-eslint/experimental-utils": "4.3.0",
-                "@typescript-eslint/scope-manager": "4.3.0",
+                "@typescript-eslint/experimental-utils": "4.5.0",
+                "@typescript-eslint/scope-manager": "4.5.0",
                 "debug": "^4.1.1",
                 "functional-red-black-tree": "^1.0.1",
                 "regexpp": "^3.0.0",
@@ -3471,14 +3938,14 @@
             }
         },
         "@typescript-eslint/experimental-utils": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.3.0.tgz",
-            "integrity": "sha512-cmmIK8shn3mxmhpKfzMMywqiEheyfXLV/+yPDnOTvQX/ztngx7Lg/OD26J8gTZfkLKUmaEBxO2jYP3keV7h2OQ==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.5.0.tgz",
+            "integrity": "sha512-bW9IpSAKYvkqDGRZzayBXIgPsj2xmmVHLJ+flGSoN0fF98pGoKFhbunIol0VF2Crka7z984EEhFi623Rl7e6gg==",
             "requires": {
                 "@types/json-schema": "^7.0.3",
-                "@typescript-eslint/scope-manager": "4.3.0",
-                "@typescript-eslint/types": "4.3.0",
-                "@typescript-eslint/typescript-estree": "4.3.0",
+                "@typescript-eslint/scope-manager": "4.5.0",
+                "@typescript-eslint/types": "4.5.0",
+                "@typescript-eslint/typescript-estree": "4.5.0",
                 "eslint-scope": "^5.0.0",
                 "eslint-utils": "^2.0.0"
             },
@@ -3495,37 +3962,37 @@
             }
         },
         "@typescript-eslint/parser": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.3.0.tgz",
-            "integrity": "sha512-JyfRnd72qRuUwItDZ00JNowsSlpQGeKfl9jxwO0FHK1qQ7FbYdoy5S7P+5wh1ISkT2QyAvr2pc9dAemDxzt75g==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.5.0.tgz",
+            "integrity": "sha512-xb+gmyhQcnDWe+5+xxaQk5iCw6KqXd8VQxGiTeELTMoYeRjpocZYYRP1gFVM2C8Yl0SpUvLa1lhprwqZ00w3Iw==",
             "requires": {
-                "@typescript-eslint/scope-manager": "4.3.0",
-                "@typescript-eslint/types": "4.3.0",
-                "@typescript-eslint/typescript-estree": "4.3.0",
+                "@typescript-eslint/scope-manager": "4.5.0",
+                "@typescript-eslint/types": "4.5.0",
+                "@typescript-eslint/typescript-estree": "4.5.0",
                 "debug": "^4.1.1"
             }
         },
         "@typescript-eslint/scope-manager": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.3.0.tgz",
-            "integrity": "sha512-cTeyP5SCNE8QBRfc+Lgh4Xpzje46kNUhXYfc3pQWmJif92sjrFuHT9hH4rtOkDTo/si9Klw53yIr+djqGZS1ig==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.5.0.tgz",
+            "integrity": "sha512-C0cEO0cTMPJ/w4RA/KVe4LFFkkSh9VHoFzKmyaaDWAnPYIEzVCtJ+Un8GZoJhcvq+mPFXEsXa01lcZDHDG6Www==",
             "requires": {
-                "@typescript-eslint/types": "4.3.0",
-                "@typescript-eslint/visitor-keys": "4.3.0"
+                "@typescript-eslint/types": "4.5.0",
+                "@typescript-eslint/visitor-keys": "4.5.0"
             }
         },
         "@typescript-eslint/types": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.3.0.tgz",
-            "integrity": "sha512-Cx9TpRvlRjOppGsU6Y6KcJnUDOelja2NNCX6AZwtVHRzaJkdytJWMuYiqi8mS35MRNA3cJSwDzXePfmhU6TANw=="
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.5.0.tgz",
+            "integrity": "sha512-n2uQoXnyWNk0Les9MtF0gCK3JiWd987JQi97dMSxBOzVoLZXCNtxFckVqt1h8xuI1ix01t+iMY4h4rFMj/303g=="
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.3.0.tgz",
-            "integrity": "sha512-ZAI7xjkl+oFdLV/COEz2tAbQbR3XfgqHEGy0rlUXzfGQic6EBCR4s2+WS3cmTPG69aaZckEucBoTxW9PhzHxxw==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.5.0.tgz",
+            "integrity": "sha512-gN1mffq3zwRAjlYWzb5DanarOPdajQwx5MEWkWCk0XvqC8JpafDTeioDoow2L4CA/RkYZu7xEsGZRhqrTsAG8w==",
             "requires": {
-                "@typescript-eslint/types": "4.3.0",
-                "@typescript-eslint/visitor-keys": "4.3.0",
+                "@typescript-eslint/types": "4.5.0",
+                "@typescript-eslint/visitor-keys": "4.5.0",
                 "debug": "^4.1.1",
                 "globby": "^11.0.1",
                 "is-glob": "^4.0.1",
@@ -3608,15 +4075,20 @@
                     "version": "7.3.2",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
                     "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+                },
+                "slash": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+                    "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
                 }
             }
         },
         "@typescript-eslint/visitor-keys": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.3.0.tgz",
-            "integrity": "sha512-xZxkuR7XLM6RhvLkgv9yYlTcBHnTULzfnw4i6+z2TGBLy9yljAypQaZl9c3zFvy7PNI7fYWyvKYtohyF8au3cw==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.5.0.tgz",
+            "integrity": "sha512-UHq4FSa55NDZqscRU//O5ROFhHa9Hqn9KWTEvJGTArtTQp5GKv9Zqf6d/Q3YXXcFv4woyBml7fJQlQ+OuqRcHA==",
             "requires": {
-                "@typescript-eslint/types": "4.3.0",
+                "@typescript-eslint/types": "4.5.0",
                 "eslint-visitor-keys": "^2.0.0"
             }
         },
@@ -3826,6 +4298,12 @@
             "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
         },
+        "abab": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+            "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
+            "dev": true
+        },
         "accepts": {
             "version": "1.3.7",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -3836,10 +4314,27 @@
             }
         },
         "acorn": {
-            "version": "7.4.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
-            "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
-            "dev": true
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+            "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ=="
+        },
+        "acorn-globals": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+            "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+            "dev": true,
+            "requires": {
+                "acorn": "^7.1.1",
+                "acorn-walk": "^7.1.1"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "7.4.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+                    "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+                    "dev": true
+                }
+            }
         },
         "acorn-jsx": {
             "version": "5.3.1",
@@ -3892,9 +4387,9 @@
             }
         },
         "ajv": {
-            "version": "6.12.5",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
-            "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "requires": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -4070,6 +4565,26 @@
                 "define-properties": "^1.1.3",
                 "es-abstract": "^1.17.0",
                 "is-string": "^1.0.5"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                }
             }
         },
         "array-union": {
@@ -4097,6 +4612,26 @@
             "requires": {
                 "define-properties": "^1.1.3",
                 "es-abstract": "^1.17.0-next.1"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                }
             }
         },
         "array.prototype.flatmap": {
@@ -4107,6 +4642,26 @@
                 "define-properties": "^1.1.3",
                 "es-abstract": "^1.17.0-next.1",
                 "function-bind": "^1.1.1"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                }
             }
         },
         "array.prototype.map": {
@@ -4118,12 +4673,41 @@
                 "es-abstract": "^1.17.0-next.1",
                 "es-array-method-boxes-properly": "^1.0.0",
                 "is-string": "^1.0.4"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                }
             }
         },
         "arrify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
             "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+        },
+        "asn1": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+            "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+            "dev": true,
+            "requires": {
+                "safer-buffer": "~2.1.0"
+            }
         },
         "asn1.js": {
             "version": "5.4.1",
@@ -4167,23 +4751,29 @@
                 }
             }
         },
+        "assert-plus": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+            "dev": true
+        },
         "assign-symbols": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
             "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
         },
         "ast-types": {
-            "version": "0.13.4",
-            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
-            "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+            "version": "0.14.2",
+            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
+            "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
             "requires": {
                 "tslib": "^2.0.1"
             },
             "dependencies": {
                 "tslib": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
-                    "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+                    "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
                 }
             }
         },
@@ -4255,104 +4845,6 @@
                 "webpack-log": "^1.2.0"
             },
             "dependencies": {
-                "braces": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-                    "dev": true,
-                    "requires": {
-                        "arr-flatten": "^1.1.0",
-                        "array-unique": "^0.3.2",
-                        "extend-shallow": "^2.0.1",
-                        "fill-range": "^4.0.0",
-                        "isobject": "^3.0.1",
-                        "repeat-element": "^1.1.2",
-                        "snapdragon": "^0.8.1",
-                        "snapdragon-node": "^2.0.1",
-                        "split-string": "^3.0.2",
-                        "to-regex": "^3.0.1"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "dev": true,
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "fill-range": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-                    "dev": true,
-                    "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1",
-                        "to-regex-range": "^2.1.0"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "dev": true,
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "is-number": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "dev": true,
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
-                    }
-                },
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
-                },
-                "json5": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-                    "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-                    "dev": true,
-                    "requires": {
-                        "minimist": "^1.2.0"
-                    }
-                },
-                "loader-utils": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-                    "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-                    "dev": true,
-                    "requires": {
-                        "big.js": "^5.2.2",
-                        "emojis-list": "^3.0.0",
-                        "json5": "^1.0.1"
-                    }
-                },
                 "micromatch": {
                     "version": "3.1.10",
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -4374,16 +4866,6 @@
                         "to-regex": "^3.0.2"
                     }
                 },
-                "to-regex-range": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-                    "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-                    "dev": true,
-                    "requires": {
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1"
-                    }
-                },
                 "webpack-log": {
                     "version": "1.2.0",
                     "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-1.2.0.tgz",
@@ -4397,6 +4879,18 @@
                     }
                 }
             }
+        },
+        "aws-sign2": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+            "dev": true
+        },
+        "aws4": {
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
+            "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
+            "dev": true
         },
         "axe-core": {
             "version": "3.5.5",
@@ -4484,6 +4978,79 @@
             "resolved": "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.5.0.tgz",
             "integrity": "sha512-m2CvfDW4+1qfDdsrtf4dwOslQC3yhbgyBFptncp4wvtdrDHqueW7slsYv4gArie056phvQFhT2nRcGS4bnm6mA=="
         },
+        "babel-jest": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.1.tgz",
+            "integrity": "sha512-duMWEOKrSBYRVTTNpL2SipNIWnZOjP77auOBMPQ3zXAdnDbyZQWU8r/RxNWpUf9N6cgPFecQYelYLytTVXVDtA==",
+            "dev": true,
+            "requires": {
+                "@jest/transform": "^26.6.1",
+                "@jest/types": "^26.6.1",
+                "@types/babel__core": "^7.1.7",
+                "babel-plugin-istanbul": "^6.0.0",
+                "babel-preset-jest": "^26.5.0",
+                "chalk": "^4.0.0",
+                "graceful-fs": "^4.2.4",
+                "slash": "^3.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "slash": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+                    "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
         "babel-loader": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.1.0.tgz",
@@ -4494,26 +5061,6 @@
                 "mkdirp": "^0.5.3",
                 "pify": "^4.0.1",
                 "schema-utils": "^2.6.5"
-            },
-            "dependencies": {
-                "json5": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-                    "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-                    "requires": {
-                        "minimist": "^1.2.0"
-                    }
-                },
-                "loader-utils": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-                    "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-                    "requires": {
-                        "big.js": "^5.2.2",
-                        "emojis-list": "^3.0.0",
-                        "json5": "^1.0.1"
-                    }
-                }
             }
         },
         "babel-plugin-add-react-displayname": {
@@ -4522,13 +5069,13 @@
             "integrity": "sha1-M51M3be2X9YtHfnbn+BN4TQSK9U="
         },
         "babel-plugin-apply-mdx-type-prop": {
-            "version": "1.6.18",
-            "resolved": "https://registry.npmjs.org/babel-plugin-apply-mdx-type-prop/-/babel-plugin-apply-mdx-type-prop-1.6.18.tgz",
-            "integrity": "sha512-lcpbj/GatKQp48jsJ8Os/ZXv381ZYFNKA27EPllcpFMpqiS696XkoK+xie/2GjzQSe5IIbo3srsXpd6/ik8PsQ==",
+            "version": "1.6.19",
+            "resolved": "https://registry.npmjs.org/babel-plugin-apply-mdx-type-prop/-/babel-plugin-apply-mdx-type-prop-1.6.19.tgz",
+            "integrity": "sha512-zAuL11EaBbeNpfTqsa9xP7mkvX3V4LaEV6M9UUaI4zQtTqN5JwvDyhNsALQs5Ud7WFQSXtoqU74saTgE+rgZOw==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "7.10.4",
-                "@mdx-js/util": "1.6.18"
+                "@mdx-js/util": "1.6.19"
             }
         },
         "babel-plugin-dynamic-import-node": {
@@ -4557,9 +5104,9 @@
             }
         },
         "babel-plugin-extract-import-names": {
-            "version": "1.6.18",
-            "resolved": "https://registry.npmjs.org/babel-plugin-extract-import-names/-/babel-plugin-extract-import-names-1.6.18.tgz",
-            "integrity": "sha512-2EyZia3Ezl3UdhBcgDl6KZTNkYa2VhmAHHbJdhCroa1pZD/E56BulVsSKIhm/kza9agnabDR2VEHO+ZnqpfxbQ==",
+            "version": "1.6.19",
+            "resolved": "https://registry.npmjs.org/babel-plugin-extract-import-names/-/babel-plugin-extract-import-names-1.6.19.tgz",
+            "integrity": "sha512-5kbSEhQdg1ybR9OnxybbyR1PXw51z6T6ZCtX3vYSU6t1pC/+eBlSzWXyU2guStbwQgJyxS+mHWSNnL7PUdzAlw==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "7.10.4"
@@ -4576,6 +5123,18 @@
                 "@istanbuljs/schema": "^0.1.2",
                 "istanbul-lib-instrument": "^4.0.0",
                 "test-exclude": "^6.0.0"
+            }
+        },
+        "babel-plugin-jest-hoist": {
+            "version": "26.5.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.5.0.tgz",
+            "integrity": "sha512-ck17uZFD3CDfuwCLATWZxkkuGGFhMij8quP8CNhwj8ek1mqFgbFzRJ30xwC04LLscj/aKsVFfRST+b5PT7rSuw==",
+            "dev": true,
+            "requires": {
+                "@babel/template": "^7.3.3",
+                "@babel/types": "^7.3.3",
+                "@types/babel__core": "^7.0.0",
+                "@types/babel__traverse": "^7.0.6"
             }
         },
         "babel-plugin-macros": {
@@ -4685,18 +5244,18 @@
             }
         },
         "babel-plugin-named-asset-import": {
-            "version": "0.3.6",
-            "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.6.tgz",
-            "integrity": "sha512-1aGDUfL1qOOIoqk9QKGIo2lANk+C7ko/fqH0uIyC71x3PEGz0uVP8ISgfEsFuG+FKmjHTvFK/nNM8dowpmUxLA=="
+            "version": "0.3.7",
+            "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.7.tgz",
+            "integrity": "sha512-squySRkf+6JGnvjoUtDEjSREJEBirnXi9NqP6rjSYsylxQxqBTz+pkmf395i9E2zsvmYUaI40BHo6SqZUdydlw=="
         },
         "babel-plugin-react-docgen": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-react-docgen/-/babel-plugin-react-docgen-4.2.0.tgz",
-            "integrity": "sha512-B3tjZwKskcia9TsqkND+9OTjl/F5A5OBvRJ6Ktg34CONoxm+kB3CJ52wk5TjbszX9gqCPcAuc0GgkhT0CLuT/Q==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-react-docgen/-/babel-plugin-react-docgen-4.2.1.tgz",
+            "integrity": "sha512-UQ0NmGHj/HAqi5Bew8WvNfCk8wSsmdgNd8ZdMjBCICtyCJCq9LiqgqvjCYe570/Wg7AQArSq1VQ60Dd/CHN7mQ==",
             "requires": {
+                "ast-types": "^0.14.2",
                 "lodash": "^4.17.15",
-                "react-docgen": "^5.0.0",
-                "recast": "^0.14.7"
+                "react-docgen": "^5.0.0"
             }
         },
         "babel-plugin-recharts": {
@@ -4786,6 +5345,35 @@
             "version": "6.9.4",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz",
             "integrity": "sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA="
+        },
+        "babel-preset-current-node-syntax": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.4.tgz",
+            "integrity": "sha512-5/INNCYhUGqw7VbVjT/hb3ucjgkVHKXY7lX3ZjlN4gm565VyFmJUrJ/h+h16ECVB38R/9SF6aACydpKMLZ/c9w==",
+            "dev": true,
+            "requires": {
+                "@babel/plugin-syntax-async-generators": "^7.8.4",
+                "@babel/plugin-syntax-bigint": "^7.8.3",
+                "@babel/plugin-syntax-class-properties": "^7.8.3",
+                "@babel/plugin-syntax-import-meta": "^7.8.3",
+                "@babel/plugin-syntax-json-strings": "^7.8.3",
+                "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+                "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+                "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+            }
+        },
+        "babel-preset-jest": {
+            "version": "26.5.0",
+            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.5.0.tgz",
+            "integrity": "sha512-F2vTluljhqkiGSJGBg/jOruA8vIIIL11YrxRcO7nviNTMbbofPSHwnm8mgP7d/wS7wRSexRoI6X1A6T74d4LQA==",
+            "dev": true,
+            "requires": {
+                "babel-plugin-jest-hoist": "^26.5.0",
+                "babel-preset-current-node-syntax": "^0.1.3"
+            }
         },
         "babel-preset-minify": {
             "version": "0.5.1",
@@ -4898,10 +5486,19 @@
             "resolved": "https://registry.npmjs.org/batch-processor/-/batch-processor-1.0.0.tgz",
             "integrity": "sha1-dclcMrdI4IUNEMKxaPa9vpiRrOg="
         },
+        "bcrypt-pbkdf": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+            "dev": true,
+            "requires": {
+                "tweetnacl": "^0.14.3"
+            }
+        },
         "better-opn": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/better-opn/-/better-opn-2.0.0.tgz",
-            "integrity": "sha512-PPbGRgO/K0LowMHbH/JNvaV3qY3Vt+A2nH28fzJxy16h/DfR5OsVti6ldGl6S9SMsyUqT13sltikiAVtI6tKLA==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/better-opn/-/better-opn-2.1.1.tgz",
+            "integrity": "sha512-kIPXZS5qwyKiX/HcRvDYfmBQUa8XP17I0mYZZ0y4UhpYOSvtsLHDYqmomS+Mj20aDvD3knEiQ0ecQy2nhio3yA==",
             "requires": {
                 "open": "^7.0.3"
             }
@@ -4915,15 +5512,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
             "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
-        },
-        "bindings": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-            "optional": true,
-            "requires": {
-                "file-uri-to-path": "1.0.0"
-            }
         },
         "bluebird": {
             "version": "3.7.2",
@@ -4998,11 +5586,10 @@
                     "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
                 },
                 "ansi-styles": {
-                    "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
                     "requires": {
-                        "@types/color-name": "^1.1.1",
                         "color-convert": "^2.0.1"
                     }
                 },
@@ -5081,17 +5668,47 @@
             }
         },
         "braces": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+            "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
             "requires": {
-                "fill-range": "^7.0.1"
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+                }
             }
         },
         "brorand": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
             "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+        },
+        "browser-process-hrtime": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+            "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
+            "dev": true
         },
         "browserify-aes": {
             "version": "1.2.0",
@@ -5193,6 +5810,15 @@
                 "electron-to-chromium": "^1.3.571",
                 "escalade": "^3.1.0",
                 "node-releases": "^1.1.61"
+            }
+        },
+        "bs-logger": {
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+            "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+            "dev": true,
+            "requires": {
+                "fast-json-stable-stringify": "2.x"
             }
         },
         "bser": {
@@ -5356,9 +5982,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001140",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001140.tgz",
-            "integrity": "sha512-xFtvBtfGrpjTOxTpjP5F2LmN04/ZGfYV8EQzUIC/RmKpdrmzJrjqlJ4ho7sGuAMPko2/Jl08h7x9uObCfBFaAA=="
+            "version": "1.0.30001150",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001150.tgz",
+            "integrity": "sha512-kiNKvihW0m36UhAFnl7bOAv0i1K1f6wpfVtTF5O5O82XzgtBnb05V0XeV3oZ968vfg2sRNChsHw8ASH2hDfoYQ=="
         },
         "capture-exit": {
             "version": "2.0.0",
@@ -5373,6 +5999,12 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.3.0.tgz",
             "integrity": "sha512-/4YgnZS8y1UXXmC02xD5rRrBEu6T5ub+mQHLNRj0fzTRbgdBYhsNo2V5EqwgqrExjxsjtF/OpAKAMkKsxbD5XQ=="
+        },
+        "caseless": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+            "dev": true
         },
         "ccount": {
             "version": "1.0.5",
@@ -5389,6 +6021,12 @@
                 "escape-string-regexp": "^1.0.5",
                 "supports-color": "^5.3.0"
             }
+        },
+        "char-regex": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+            "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+            "dev": true
         },
         "character-entities": {
             "version": "1.2.4",
@@ -5411,9 +6049,9 @@
             "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
         },
         "chokidar": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
-            "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
+            "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
             "requires": {
                 "anymatch": "~3.1.1",
                 "braces": "~3.0.2",
@@ -5422,9 +6060,25 @@
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",
                 "normalize-path": "~3.0.0",
-                "readdirp": "~3.4.0"
+                "readdirp": "~3.5.0"
             },
             "dependencies": {
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
                 "glob-parent": {
                     "version": "5.1.1",
                     "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
@@ -5444,6 +6098,19 @@
                     "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
                     "requires": {
                         "is-extglob": "^2.1.1"
+                    }
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "requires": {
+                        "is-number": "^7.0.0"
                     }
                 }
             }
@@ -5475,6 +6142,12 @@
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.0.1"
             }
+        },
+        "cjs-module-lexer": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-0.4.3.tgz",
+            "integrity": "sha512-5RLK0Qfs0PNDpEyBXIr3bIT1Muw3ojSlvpw6dAmkUcO0+uTrsBn7GuEIgx40u+OzbCBLDta7nvmud85P4EmTsQ==",
+            "dev": true
         },
         "class-utils": {
             "version": "0.3.6",
@@ -5601,6 +6274,57 @@
                 "tiny-emitter": "^2.0.0"
             }
         },
+        "cliui": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+            "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+            "dev": true,
+            "requires": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^6.2.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "emoji-regex": {
+                    "version": "8.0.0",
+                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+                    "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+                    "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.0"
+                    }
+                }
+            }
+        },
         "clone-deep": {
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
@@ -5628,6 +6352,12 @@
             "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
             "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
         },
+        "co": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+            "dev": true
+        },
         "coa": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
@@ -5647,6 +6377,12 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
             "integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==",
+            "dev": true
+        },
+        "collect-v8-coverage": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
+            "integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
             "dev": true
         },
         "collection-visit": {
@@ -5733,9 +6469,9 @@
             }
         },
         "confusing-browser-globals": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz",
-            "integrity": "sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==",
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
+            "integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==",
             "dev": true
         },
         "console-browserify": {
@@ -5910,24 +6646,13 @@
             }
         },
         "cross-spawn": {
-            "version": "6.0.5",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-            "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-            "dev": true,
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+            "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
             "requires": {
-                "nice-try": "^1.0.4",
-                "path-key": "^2.0.1",
-                "semver": "^5.5.0",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-                    "dev": true
-                }
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
             }
         },
         "crypto-browserify": {
@@ -5982,24 +6707,6 @@
                 "semver": "^6.3.0"
             },
             "dependencies": {
-                "json5": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-                    "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-                    "requires": {
-                        "minimist": "^1.2.0"
-                    }
-                },
-                "loader-utils": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-                    "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-                    "requires": {
-                        "big.js": "^5.2.2",
-                        "emojis-list": "^3.0.0",
-                        "json5": "^1.0.1"
-                    }
-                },
                 "semver": {
                     "version": "6.3.0",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -6089,10 +6796,33 @@
                 }
             }
         },
+        "cssom": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+            "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
+            "dev": true
+        },
+        "cssstyle": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+            "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+            "dev": true,
+            "requires": {
+                "cssom": "~0.3.6"
+            },
+            "dependencies": {
+                "cssom": {
+                    "version": "0.3.8",
+                    "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+                    "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+                    "dev": true
+                }
+            }
+        },
         "csstype": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
-            "integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag=="
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.4.tgz",
+            "integrity": "sha512-xc8DUsCLmjvCfoD7LTGE0ou2MIWLx0K9RCZwSHMOdynqRsP4MtUcLeqh1HcQ2dInwDTqn+3CE0/FZh1et+p4jA=="
         },
         "cyclist": {
             "version": "1.0.1",
@@ -6181,6 +6911,26 @@
             "integrity": "sha512-JVrozIeElnj3QzfUIt8tB8YMluBJom4Vw9qTPpjGYQ9fYlB3D/rb6OordUxf3xeFB35LKWs0xqcO5U6ySvBtug==",
             "dev": true
         },
+        "dashdash": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0"
+            }
+        },
+        "data-urls": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+            "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+            "dev": true,
+            "requires": {
+                "abab": "^2.0.3",
+                "whatwg-mimetype": "^2.3.0",
+                "whatwg-url": "^8.0.0"
+            }
+        },
         "debug": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
@@ -6189,10 +6939,22 @@
                 "ms": "2.1.2"
             }
         },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
+        },
+        "decimal.js": {
+            "version": "10.2.1",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
+            "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==",
+            "dev": true
+        },
         "decimal.js-light": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.0.tgz",
-            "integrity": "sha512-b3VJCbd2hwUpeRGG3Toob+CRo8W22xplipNhP3tN7TSVB/cyMX71P1vM2Xjc9H74uV6dS2hDDmo/rHq8L87Upg=="
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+            "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
         },
         "decode-uri-component": {
             "version": "0.2.0",
@@ -6227,6 +6989,12 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/deep-object-diff/-/deep-object-diff-1.1.0.tgz",
             "integrity": "sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw=="
+        },
+        "deepmerge": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+            "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+            "dev": true
         },
         "define-properties": {
             "version": "1.1.3",
@@ -6322,6 +7090,12 @@
                 "repeat-string": "^1.5.4"
             }
         },
+        "detect-newline": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+            "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+            "dev": true
+        },
         "detect-port": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.3.0.tgz",
@@ -6345,6 +7119,12 @@
                     "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 }
             }
+        },
+        "diff-sequences": {
+            "version": "26.5.0",
+            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.5.0.tgz",
+            "integrity": "sha512-ZXx86srb/iYy6jG71k++wBN9P9J05UNQ5hQHQd9MtMPvcqXPx/vKU69jfHV637D00Q2gSgPk2D+jSx3l1lDW/Q==",
+            "dev": true
         },
         "diffie-hellman": {
             "version": "5.0.3",
@@ -6426,9 +7206,9 @@
                     "integrity": "sha512-wFwTwCVebUrMgGeAwRL/NhZtHAUyT9n9yg4IMDwf10+6iCMxSkVq9MGCVEH+QZWo1nNidy8kNvwmv4zWHDTqvA=="
                 },
                 "entities": {
-                    "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
-                    "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+                    "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
                 }
             }
         },
@@ -6446,6 +7226,23 @@
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
             "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+        },
+        "domexception": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
+            "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
+            "dev": true,
+            "requires": {
+                "webidl-conversions": "^5.0.0"
+            },
+            "dependencies": {
+                "webidl-conversions": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+                    "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+                    "dev": true
+                }
+            }
         },
         "domhandler": {
             "version": "2.4.2",
@@ -6515,6 +7312,16 @@
                 "stream-shift": "^1.0.0"
             }
         },
+        "ecc-jsbn": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+            "dev": true,
+            "requires": {
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
+            }
+        },
         "ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -6529,9 +7336,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.3.576",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.576.tgz",
-            "integrity": "sha512-uSEI0XZ//5ic+0NdOqlxp0liCD44ck20OAGyLMSymIWTEAtHKVJi6JM18acOnRgUgX7Q65QqnI+sNncNvIy8ew=="
+            "version": "1.3.583",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.583.tgz",
+            "integrity": "sha512-L9BwLwJohjZW9mQESI79HRzhicPk1DFgM+8hOCfGgGCFEcA3Otpv7QK6SGtYoZvfQfE3wKLh0Hd5ptqUFv3gvQ=="
         },
         "element-resize-detector": {
             "version": "1.2.1",
@@ -6561,6 +7368,12 @@
                     "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
                 }
             }
+        },
+        "emittery": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.2.tgz",
+            "integrity": "sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ==",
+            "dev": true
         },
         "emoji-mart": {
             "version": "3.0.0",
@@ -6674,19 +7487,20 @@
             }
         },
         "es-abstract": {
-            "version": "1.17.6",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-            "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+            "version": "1.18.0-next.1",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+            "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
             "requires": {
                 "es-to-primitive": "^1.2.1",
                 "function-bind": "^1.1.1",
                 "has": "^1.0.3",
                 "has-symbols": "^1.0.1",
-                "is-callable": "^1.2.0",
-                "is-regex": "^1.1.0",
-                "object-inspect": "^1.7.0",
+                "is-callable": "^1.2.2",
+                "is-negative-zero": "^2.0.0",
+                "is-regex": "^1.1.1",
+                "object-inspect": "^1.8.0",
                 "object-keys": "^1.1.1",
-                "object.assign": "^4.1.0",
+                "object.assign": "^4.1.1",
                 "string.prototype.trimend": "^1.0.1",
                 "string.prototype.trimstart": "^1.0.1"
             }
@@ -6710,6 +7524,24 @@
                 "isarray": "^2.0.5"
             },
             "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                },
                 "isarray": {
                     "version": "2.0.5",
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -6753,9 +7585,9 @@
             }
         },
         "es6-shim": {
-            "version": "0.35.5",
-            "resolved": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.35.5.tgz",
-            "integrity": "sha512-E9kK/bjtCQRpN1K28Xh4BlmP8egvZBGJJ+9GtnzOwt7mdqtrjHFuVGr7QJfdjBIKqrlU5duPf3pCBoDrkjVYFg=="
+            "version": "0.35.6",
+            "resolved": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.35.6.tgz",
+            "integrity": "sha512-EmTr31wppcaIAgblChZiuN/l9Y7DPyw8Xtbg7fIVngn6zMW+IEBJDJngeKC3x6wr0V/vcA2wqeFnaw1bFJbDdA=="
         },
         "es6-symbol": {
             "version": "3.1.3",
@@ -6767,9 +7599,9 @@
             }
         },
         "escalade": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.0.tgz",
-            "integrity": "sha512-mAk+hPSO8fLDkhV7V0dXazH5pDc6MrjBTPyD3VeKzxnVFjH1MIxbCdqGZB9O8+EwWakZs3ZCbDS4IpRt79V1ig=="
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
         },
         "escape-html": {
             "version": "1.0.3",
@@ -6804,9 +7636,9 @@
             }
         },
         "eslint": {
-            "version": "7.10.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.10.0.tgz",
-            "integrity": "sha512-BDVffmqWl7JJXqCjAK6lWtcQThZB/aP1HXSH1JKwGwv0LQEdvpR7qzNrUT487RM39B5goWuboFad5ovMBmD8yA==",
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.11.0.tgz",
+            "integrity": "sha512-G9+qtYVCHaDi1ZuWzBsOWo2wSwd70TXnU6UHA3cTYHp7gCTXZcpggWFoUVAMRarg68qtPoNfFbzPh+VdOgmwmw==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
@@ -6819,7 +7651,7 @@
                 "enquirer": "^2.3.5",
                 "eslint-scope": "^5.1.1",
                 "eslint-utils": "^2.1.0",
-                "eslint-visitor-keys": "^1.3.0",
+                "eslint-visitor-keys": "^2.0.0",
                 "espree": "^7.3.0",
                 "esquery": "^1.2.0",
                 "esutils": "^2.0.2",
@@ -6855,12 +7687,11 @@
                     "dev": true
                 },
                 "ansi-styles": {
-                    "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "^1.1.1",
                         "color-convert": "^2.0.1"
                     }
                 },
@@ -6909,12 +7740,6 @@
                         "esrecurse": "^4.3.0",
                         "estraverse": "^4.1.1"
                     }
-                },
-                "eslint-visitor-keys": {
-                    "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-                    "dev": true
                 },
                 "glob-parent": {
                     "version": "5.1.1",
@@ -6985,12 +7810,6 @@
                         "word-wrap": "^1.2.3"
                     }
                 },
-                "path-key": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-                    "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-                    "dev": true
-                },
                 "prelude-ls": {
                     "version": "1.2.1",
                     "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -7001,21 +7820,6 @@
                     "version": "7.3.2",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
                     "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-                    "dev": true
-                },
-                "shebang-command": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-                    "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-                    "dev": true,
-                    "requires": {
-                        "shebang-regex": "^3.0.0"
-                    }
-                },
-                "shebang-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-                    "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
                     "dev": true
                 },
                 "strip-ansi": {
@@ -7044,15 +7848,6 @@
                     "requires": {
                         "prelude-ls": "^1.2.1"
                     }
-                },
-                "which": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-                    "dev": true,
-                    "requires": {
-                        "isexe": "^2.0.0"
-                    }
                 }
             }
         },
@@ -7079,9 +7874,9 @@
             }
         },
         "eslint-config-prettier": {
-            "version": "6.12.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.12.0.tgz",
-            "integrity": "sha512-9jWPlFlgNwRUYVoujvWTQ1aMO8o6648r+K7qU7K5Jmkbyqav1fuEZC0COYpGBxyiAJb65Ra9hrmFx19xRGwXWw==",
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.14.0.tgz",
+            "integrity": "sha512-DbVwh0qZhAC7CNDWcq8cBdK6FcVHiMTKmCypOPWeZkp9hJ8xYwTaWSa6bb6cjfi8KOeJy0e9a8Izxyx+O4+gCQ==",
             "dev": true,
             "requires": {
                 "get-stdin": "^6.0.0"
@@ -7273,29 +8068,29 @@
             },
             "dependencies": {
                 "emoji-regex": {
-                    "version": "9.0.0",
-                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.0.0.tgz",
-                    "integrity": "sha512-6p1NII1Vm62wni/VR/cUMauVQoxmLVb9csqQlvLz+hO2gk8U2UYDfXHQSUYIBKmZwAKz867IDqG7B+u0mj+M6w==",
+                    "version": "9.2.0",
+                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.0.tgz",
+                    "integrity": "sha512-DNc3KFPK18bPdElMJnf/Pkv5TXhxFU3YFDEuGLDRtPmV4rkmCjBkCSEp22u6rBHdSN9Vlp/GK7k98prmE1Jgug==",
                     "dev": true
                 }
             }
         },
         "eslint-plugin-react": {
-            "version": "7.21.2",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.21.2.tgz",
-            "integrity": "sha512-j3XKvrK3rpBzveKFbgAeGsWb9uz6iUOrR0jixRfjwdFeGSRsXvVTFtHDQYCjsd1/6Z/xvb8Vy3LiI5Reo7fDrg==",
+            "version": "7.21.5",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.21.5.tgz",
+            "integrity": "sha512-8MaEggC2et0wSF6bUeywF7qQ46ER81irOdWS4QWxnnlAEsnzeBevk1sWh7fhpCghPpXb+8Ks7hvaft6L/xsR6g==",
             "dev": true,
             "requires": {
                 "array-includes": "^3.1.1",
                 "array.prototype.flatmap": "^1.2.3",
                 "doctrine": "^2.1.0",
                 "has": "^1.0.3",
-                "jsx-ast-utils": "^2.4.1",
+                "jsx-ast-utils": "^2.4.1 || ^3.0.0",
                 "object.entries": "^1.1.2",
                 "object.fromentries": "^2.0.2",
                 "object.values": "^1.1.1",
                 "prop-types": "^15.7.2",
-                "resolve": "^1.17.0",
+                "resolve": "^1.18.1",
                 "string.prototype.matchall": "^4.0.2"
             },
             "dependencies": {
@@ -7350,6 +8145,12 @@
                 "eslint-visitor-keys": "^1.3.0"
             },
             "dependencies": {
+                "acorn": {
+                    "version": "7.4.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+                    "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+                    "dev": true
+                },
                 "eslint-visitor-keys": {
                     "version": "1.3.0",
                     "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
@@ -7443,7 +8244,64 @@
                 "p-finally": "^1.0.0",
                 "signal-exit": "^3.0.0",
                 "strip-eof": "^1.0.0"
+            },
+            "dependencies": {
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                    "dev": true,
+                    "requires": {
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "path-key": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+                    "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
+                },
+                "shebang-command": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+                    "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+                    "dev": true,
+                    "requires": {
+                        "shebang-regex": "^1.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+                    "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+                    "dev": true
+                },
+                "which": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+                    "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
             }
+        },
+        "exit": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+            "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+            "dev": true
         },
         "expand-brackets": {
             "version": "2.1.4",
@@ -7487,6 +8345,46 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                     "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                }
+            }
+        },
+        "expect": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/expect/-/expect-26.6.1.tgz",
+            "integrity": "sha512-BRfxIBHagghMmr1D2MRY0Qv5d3Nc8HCqgbDwNXw/9izmM5eBb42a2YjLKSbsqle76ozGkAEPELQX4IdNHAKRNA==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.6.1",
+                "ansi-styles": "^4.0.0",
+                "jest-get-type": "^26.3.0",
+                "jest-matcher-utils": "^26.6.1",
+                "jest-message-util": "^26.6.1",
+                "jest-regex-util": "^26.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
                 }
             }
         },
@@ -7656,6 +8554,12 @@
                 }
             }
         },
+        "extsprintf": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+            "dev": true
+        },
         "fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -7674,54 +8578,6 @@
                 "micromatch": "^3.1.10"
             },
             "dependencies": {
-                "braces": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-                    "requires": {
-                        "arr-flatten": "^1.1.0",
-                        "array-unique": "^0.3.2",
-                        "extend-shallow": "^2.0.1",
-                        "fill-range": "^4.0.0",
-                        "isobject": "^3.0.1",
-                        "repeat-element": "^1.1.2",
-                        "snapdragon": "^0.8.1",
-                        "snapdragon-node": "^2.0.1",
-                        "split-string": "^3.0.2",
-                        "to-regex": "^3.0.1"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "fill-range": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-                    "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1",
-                        "to-regex-range": "^2.1.0"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
                 "glob-parent": {
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
@@ -7754,29 +8610,6 @@
                         "is-extglob": "^2.1.1"
                     }
                 },
-                "is-number": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
-                    }
-                },
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-                },
                 "micromatch": {
                     "version": "3.1.10",
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -7795,15 +8628,6 @@
                         "regex-not": "^1.0.0",
                         "snapdragon": "^0.8.1",
                         "to-regex": "^3.0.2"
-                    }
-                },
-                "to-regex-range": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-                    "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-                    "requires": {
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1"
                     }
                 }
             }
@@ -7872,12 +8696,34 @@
             }
         },
         "file-loader": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.1.0.tgz",
-            "integrity": "sha512-26qPdHyTsArQ6gU4P1HJbAbnFTyT2r0pG7czh1GFAd9TZbj0n94wWbupgixZH/ET/meqi2/5+F7DhW4OAXD+Lg==",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.1.1.tgz",
+            "integrity": "sha512-Klt8C4BjWSXYQAfhpYYkG4qHNTna4toMHEbWrI5IuVoxbU6uiDKeKAP99R8mmbJi3lvewn/jQBOgU4+NS3tDQw==",
             "requires": {
                 "loader-utils": "^2.0.0",
-                "schema-utils": "^2.7.1"
+                "schema-utils": "^3.0.0"
+            },
+            "dependencies": {
+                "loader-utils": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+                    "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+                    "requires": {
+                        "big.js": "^5.2.2",
+                        "emojis-list": "^3.0.0",
+                        "json5": "^2.1.2"
+                    }
+                },
+                "schema-utils": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+                    "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
+                    "requires": {
+                        "@types/json-schema": "^7.0.6",
+                        "ajv": "^6.12.5",
+                        "ajv-keywords": "^3.5.2"
+                    }
+                }
             }
         },
         "file-system-cache": {
@@ -7904,12 +8750,6 @@
                 }
             }
         },
-        "file-uri-to-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-            "optional": true
-        },
         "filelist": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.1.tgz",
@@ -7924,11 +8764,24 @@
             "integrity": "sha512-u4AYWPgbI5GBhs6id1KdImZWn5yfyFrrQ8OWZdN7ZMfA8Bf4HcO0BGo9bmUIEV8yrp8I1xVfJ/dn90GtFNNJcg=="
         },
         "fill-range": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+            "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
             "requires": {
-                "to-regex-range": "^5.0.1"
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
             }
         },
         "finalhandler": {
@@ -8107,6 +8960,12 @@
                 "for-in": "^1.0.1"
             }
         },
+        "forever-agent": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+            "dev": true
+        },
         "fork-ts-checker-webpack-plugin": {
             "version": "4.1.6",
             "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-4.1.6.tgz",
@@ -8121,77 +8980,6 @@
                 "worker-rpc": "^0.1.0"
             },
             "dependencies": {
-                "braces": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-                    "requires": {
-                        "arr-flatten": "^1.1.0",
-                        "array-unique": "^0.3.2",
-                        "extend-shallow": "^2.0.1",
-                        "fill-range": "^4.0.0",
-                        "isobject": "^3.0.1",
-                        "repeat-element": "^1.1.2",
-                        "snapdragon": "^0.8.1",
-                        "snapdragon-node": "^2.0.1",
-                        "split-string": "^3.0.2",
-                        "to-regex": "^3.0.1"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "fill-range": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-                    "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1",
-                        "to-regex-range": "^2.1.0"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "is-number": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
-                    }
-                },
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-                },
                 "micromatch": {
                     "version": "3.1.10",
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -8216,15 +9004,6 @@
                     "version": "5.7.1",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                     "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                },
-                "to-regex-range": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-                    "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-                    "requires": {
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1"
-                    }
                 }
             }
         },
@@ -8341,6 +9120,26 @@
                 "define-properties": "^1.1.3",
                 "es-abstract": "^1.17.0-next.1",
                 "functions-have-names": "^1.2.0"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                }
             }
         },
         "functional-red-black-tree": {
@@ -8378,6 +9177,12 @@
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
             "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
         },
+        "get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "dev": true
+        },
         "get-package-type": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -8403,6 +9208,15 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
             "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+        },
+        "getpass": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0"
+            }
         },
         "github-slugger": {
             "version": "1.3.0",
@@ -8489,6 +9303,16 @@
                 "ini": "^1.3.5",
                 "kind-of": "^6.0.2",
                 "which": "^1.3.1"
+            },
+            "dependencies": {
+                "which": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+                    "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
             }
         },
         "globals": {
@@ -8522,11 +9346,6 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
                     "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-                },
-                "slash": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-                    "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
                 }
             }
         },
@@ -8544,6 +9363,13 @@
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
             "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
         },
+        "growly": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+            "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+            "dev": true,
+            "optional": true
+        },
         "gud": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
@@ -8556,6 +9382,22 @@
             "requires": {
                 "duplexer": "^0.1.1",
                 "pify": "^4.0.1"
+            }
+        },
+        "har-schema": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+            "dev": true
+        },
+        "har-validator": {
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+            "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+            "dev": true,
+            "requires": {
+                "ajv": "^6.12.3",
+                "har-schema": "^2.0.0"
             }
         },
         "has": {
@@ -8615,24 +9457,6 @@
                 "kind-of": "^4.0.0"
             },
             "dependencies": {
-                "is-number": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
-                    }
-                },
                 "kind-of": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
@@ -8789,10 +9613,25 @@
             "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
             "dev": true
         },
+        "html-encoding-sniffer": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+            "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+            "dev": true,
+            "requires": {
+                "whatwg-encoding": "^1.0.5"
+            }
+        },
         "html-entities": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.3.1.tgz",
             "integrity": "sha512-rhE/4Z3hIhzHAUKbW8jVcCyuT5oJCXXqhN/6mXXVCpzTmvJnoH2HL/bt3EZ6p55jbFJBeAe1ZNpL5BugLujxNA=="
+        },
+        "html-escaper": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+            "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+            "dev": true
         },
         "html-minifier-terser": {
             "version": "5.1.1",
@@ -8841,26 +9680,6 @@
                 "pretty-error": "^2.1.1",
                 "tapable": "^1.1.3",
                 "util.promisify": "1.0.0"
-            },
-            "dependencies": {
-                "json5": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-                    "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-                    "requires": {
-                        "minimist": "^1.2.0"
-                    }
-                },
-                "loader-utils": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-                    "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-                    "requires": {
-                        "big.js": "^5.2.2",
-                        "emojis-list": "^3.0.0",
-                        "json5": "^1.0.1"
-                    }
-                }
             }
         },
         "htmlparser2": {
@@ -8907,10 +9726,27 @@
                 }
             }
         },
+        "http-signature": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
+            }
+        },
         "https-browserify": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
             "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
+        },
+        "human-signals": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+            "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+            "dev": true
         },
         "husky": {
             "version": "4.3.0",
@@ -8931,12 +9767,11 @@
             },
             "dependencies": {
                 "ansi-styles": {
-                    "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "^1.1.1",
                         "color-convert": "^2.0.1"
                     }
                 },
@@ -8982,6 +9817,12 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
                     "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "slash": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+                    "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
                     "dev": true
                 },
                 "supports-color": {
@@ -9070,6 +9911,16 @@
                 }
             }
         },
+        "import-local": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
+            "integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
+            "dev": true,
+            "requires": {
+                "pkg-dir": "^4.2.0",
+                "resolve-cwd": "^3.0.0"
+            }
+        },
         "imurmurhash": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -9141,11 +9992,10 @@
                     "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
                 },
                 "ansi-styles": {
-                    "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
                     "requires": {
-                        "@types/color-name": "^1.1.1",
                         "color-convert": "^2.0.1"
                     }
                 },
@@ -9222,6 +10072,26 @@
                 "es-abstract": "^1.17.0-next.1",
                 "has": "^1.0.3",
                 "side-channel": "^1.0.2"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                }
             }
         },
         "interpret": {
@@ -9241,6 +10111,12 @@
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
             "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+        },
+        "ip-regex": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+            "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+            "dev": true
         },
         "ipaddr.js": {
             "version": "1.9.1",
@@ -9320,6 +10196,14 @@
             "dev": true,
             "requires": {
                 "ci-info": "^2.0.0"
+            }
+        },
+        "is-core-module": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.0.0.tgz",
+            "integrity": "sha512-jq1AH6C8MuteOoBPwkxHafmByhL9j5q4OaPGdbuD+ZtQJVzH+i6E3BJDQcBA09k57i2Hh2yQbEG8yObZ0jdlWw==",
+            "requires": {
+                "has": "^1.0.3"
             }
         },
         "is-data-descriptor": {
@@ -9410,6 +10294,12 @@
             "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
             "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
         },
+        "is-generator-fn": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+            "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+            "dev": true
+        },
         "is-glob": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
@@ -9434,9 +10324,22 @@
             "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE="
         },
         "is-number": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+            "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+            "requires": {
+                "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
         },
         "is-object": {
             "version": "1.0.1",
@@ -9464,6 +10367,12 @@
                     "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
                 }
             }
+        },
+        "is-potential-custom-element-name": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
+            "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
+            "dev": true
         },
         "is-regex": {
             "version": "1.1.1",
@@ -9554,6 +10463,12 @@
             "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
             "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
         },
+        "isstream": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+            "dev": true
+        },
         "istanbul-lib-coverage": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
@@ -9578,6 +10493,78 @@
                     "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
                     "dev": true
                 }
+            }
+        },
+        "istanbul-lib-report": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+            "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+            "dev": true,
+            "requires": {
+                "istanbul-lib-coverage": "^3.0.0",
+                "make-dir": "^3.0.0",
+                "supports-color": "^7.1.0"
+            },
+            "dependencies": {
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "make-dir": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+                    "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+                    "dev": true,
+                    "requires": {
+                        "semver": "^6.0.0"
+                    }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "istanbul-lib-source-maps": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
+            "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+            "dev": true,
+            "requires": {
+                "debug": "^4.1.1",
+                "istanbul-lib-coverage": "^3.0.0",
+                "source-map": "^0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "istanbul-reports": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+            "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+            "dev": true,
+            "requires": {
+                "html-escaper": "^2.0.0",
+                "istanbul-lib-report": "^3.0.0"
             }
         },
         "iterate-iterator": {
@@ -9605,43 +10592,76 @@
                 "minimatch": "^3.0.4"
             }
         },
-        "jest-haste-map": {
-            "version": "26.5.2",
-            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.5.2.tgz",
-            "integrity": "sha512-lJIAVJN3gtO3k4xy+7i2Xjtwh8CfPcH08WYjZpe9xzveDaqGw9fVNCpkYu6M525wKFVkLmyi7ku+DxCAP1lyMA==",
+        "jest": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/jest/-/jest-26.6.1.tgz",
+            "integrity": "sha512-f+ahfqw3Ffy+9vA7sWFGpTmhtKEMsNAZiWBVXDkrpIO73zIz22iimjirnV78kh/eWlylmvLh/0WxHN6fZraZdA==",
             "dev": true,
             "requires": {
-                "@jest/types": "^26.5.2",
-                "@types/graceful-fs": "^4.1.2",
-                "@types/node": "*",
-                "anymatch": "^3.0.3",
-                "fb-watchman": "^2.0.0",
-                "fsevents": "^2.1.2",
-                "graceful-fs": "^4.2.4",
-                "jest-regex-util": "^26.0.0",
-                "jest-serializer": "^26.5.0",
-                "jest-util": "^26.5.2",
-                "jest-worker": "^26.5.0",
-                "micromatch": "^4.0.2",
-                "sane": "^4.0.3",
-                "walker": "^1.0.7"
+                "@jest/core": "^26.6.1",
+                "import-local": "^3.0.2",
+                "jest-cli": "^26.6.1"
             },
             "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
                 "has-flag": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
                     "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
                     "dev": true
                 },
-                "jest-worker": {
-                    "version": "26.5.0",
-                    "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.5.0.tgz",
-                    "integrity": "sha512-kTw66Dn4ZX7WpjZ7T/SUDgRhapFRKWmisVAF0Rv4Fu8SLFD7eLbqpLvbxVqYhSgaWa7I+bW7pHnbyfNsH6stug==",
+                "jest-cli": {
+                    "version": "26.6.1",
+                    "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.1.tgz",
+                    "integrity": "sha512-aPLoEjlwFrCWhiPpW5NUxQA1X1kWsAnQcQ0SO/fHsCvczL3W75iVAcH9kP6NN+BNqZcHNEvkhxT5cDmBfEAh+w==",
                     "dev": true,
                     "requires": {
-                        "@types/node": "*",
-                        "merge-stream": "^2.0.0",
-                        "supports-color": "^7.0.0"
+                        "@jest/core": "^26.6.1",
+                        "@jest/test-result": "^26.6.1",
+                        "@jest/types": "^26.6.1",
+                        "chalk": "^4.0.0",
+                        "exit": "^0.1.2",
+                        "graceful-fs": "^4.2.4",
+                        "import-local": "^3.0.2",
+                        "is-ci": "^2.0.0",
+                        "jest-config": "^26.6.1",
+                        "jest-util": "^26.6.1",
+                        "jest-validate": "^26.6.1",
+                        "prompts": "^2.0.1",
+                        "yargs": "^15.4.1"
                     }
                 },
                 "supports-color": {
@@ -9655,11 +10675,866 @@
                 }
             }
         },
+        "jest-changed-files": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.6.1.tgz",
+            "integrity": "sha512-NhSdZ5F6b/rIN5V46x1l31vrmukD/bJUXgYAY8VtP1SknYdJwjYDRxuLt7Z8QryIdqCjMIn2C0Cd98EZ4umo8Q==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.6.1",
+                "execa": "^4.0.0",
+                "throat": "^5.0.0"
+            },
+            "dependencies": {
+                "execa": {
+                    "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
+                    "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^7.0.0",
+                        "get-stream": "^5.0.0",
+                        "human-signals": "^1.1.1",
+                        "is-stream": "^2.0.0",
+                        "merge-stream": "^2.0.0",
+                        "npm-run-path": "^4.0.0",
+                        "onetime": "^5.1.0",
+                        "signal-exit": "^3.0.2",
+                        "strip-final-newline": "^2.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+                    "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "is-stream": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+                    "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+                    "dev": true
+                },
+                "npm-run-path": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+                    "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+                    "dev": true,
+                    "requires": {
+                        "path-key": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "jest-config": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.6.1.tgz",
+            "integrity": "sha512-mtJzIynIwW1d1nMlKCNCQiSgWaqFn8cH/fOSNY97xG7Y9tBCZbCSuW2GTX0RPmceSJGO7l27JgwC18LEg0Vg+g==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "^7.1.0",
+                "@jest/test-sequencer": "^26.6.1",
+                "@jest/types": "^26.6.1",
+                "babel-jest": "^26.6.1",
+                "chalk": "^4.0.0",
+                "deepmerge": "^4.2.2",
+                "glob": "^7.1.1",
+                "graceful-fs": "^4.2.4",
+                "jest-environment-jsdom": "^26.6.1",
+                "jest-environment-node": "^26.6.1",
+                "jest-get-type": "^26.3.0",
+                "jest-jasmine2": "^26.6.1",
+                "jest-regex-util": "^26.0.0",
+                "jest-resolve": "^26.6.1",
+                "jest-util": "^26.6.1",
+                "jest-validate": "^26.6.1",
+                "micromatch": "^4.0.2",
+                "pretty-format": "^26.6.1"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "jest-diff": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.1.tgz",
+            "integrity": "sha512-BBNy/zin2m4kG5In126O8chOBxLLS/XMTuuM2+YhgyHk87ewPzKTuTJcqj3lOWOi03NNgrl+DkMeV/exdvG9gg==",
+            "dev": true,
+            "requires": {
+                "chalk": "^4.0.0",
+                "diff-sequences": "^26.5.0",
+                "jest-get-type": "^26.3.0",
+                "pretty-format": "^26.6.1"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "jest-docblock": {
+            "version": "26.0.0",
+            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-26.0.0.tgz",
+            "integrity": "sha512-RDZ4Iz3QbtRWycd8bUEPxQsTlYazfYn/h5R65Fc6gOfwozFhoImx+affzky/FFBuqISPTqjXomoIGJVKBWoo0w==",
+            "dev": true,
+            "requires": {
+                "detect-newline": "^3.0.0"
+            }
+        },
+        "jest-each": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.6.1.tgz",
+            "integrity": "sha512-gSn8eB3buchuq45SU7pLB7qmCGax1ZSxfaWuEFblCyNMtyokYaKFh9dRhYPujK6xYL57dLIPhLKatjmB5XWzGA==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.6.1",
+                "chalk": "^4.0.0",
+                "jest-get-type": "^26.3.0",
+                "jest-util": "^26.6.1",
+                "pretty-format": "^26.6.1"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "jest-environment-jsdom": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.6.1.tgz",
+            "integrity": "sha512-A17RiXuHYNVlkM+3QNcQ6n5EZyAc6eld8ra9TW26luounGWpku4tj03uqRgHJCI1d4uHr5rJiuCH5JFRtdmrcA==",
+            "dev": true,
+            "requires": {
+                "@jest/environment": "^26.6.1",
+                "@jest/fake-timers": "^26.6.1",
+                "@jest/types": "^26.6.1",
+                "@types/node": "*",
+                "jest-mock": "^26.6.1",
+                "jest-util": "^26.6.1",
+                "jsdom": "^16.4.0"
+            }
+        },
+        "jest-environment-node": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.6.1.tgz",
+            "integrity": "sha512-YffaCp6h0j1kbcf1NVZ7umC6CPgD67YS+G1BeornfuSkx5s3xdhuwG0DCxSiHPXyT81FfJzA1L7nXvhq50OWIg==",
+            "dev": true,
+            "requires": {
+                "@jest/environment": "^26.6.1",
+                "@jest/fake-timers": "^26.6.1",
+                "@jest/types": "^26.6.1",
+                "@types/node": "*",
+                "jest-mock": "^26.6.1",
+                "jest-util": "^26.6.1"
+            }
+        },
+        "jest-get-type": {
+            "version": "26.3.0",
+            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+            "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
+            "dev": true
+        },
+        "jest-haste-map": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.1.tgz",
+            "integrity": "sha512-9kPafkv0nX6ta1PrshnkiyhhoQoFWncrU/uUBt3/AP1r78WSCU5iLceYRTwDvJl67H3RrXqSlSVDDa/AsUB7OQ==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.6.1",
+                "@types/graceful-fs": "^4.1.2",
+                "@types/node": "*",
+                "anymatch": "^3.0.3",
+                "fb-watchman": "^2.0.0",
+                "fsevents": "^2.1.2",
+                "graceful-fs": "^4.2.4",
+                "jest-regex-util": "^26.0.0",
+                "jest-serializer": "^26.5.0",
+                "jest-util": "^26.6.1",
+                "jest-worker": "^26.6.1",
+                "micromatch": "^4.0.2",
+                "sane": "^4.0.3",
+                "walker": "^1.0.7"
+            }
+        },
+        "jest-jasmine2": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.6.1.tgz",
+            "integrity": "sha512-2uYdT32o/ZzSxYAPduAgokO8OlAL1YdG/9oxcEY138EDNpIK5XRRJDaGzTZdIBWSxk0aR8XxN44FvfXtHB+Fiw==",
+            "dev": true,
+            "requires": {
+                "@babel/traverse": "^7.1.0",
+                "@jest/environment": "^26.6.1",
+                "@jest/source-map": "^26.5.0",
+                "@jest/test-result": "^26.6.1",
+                "@jest/types": "^26.6.1",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "co": "^4.6.0",
+                "expect": "^26.6.1",
+                "is-generator-fn": "^2.0.0",
+                "jest-each": "^26.6.1",
+                "jest-matcher-utils": "^26.6.1",
+                "jest-message-util": "^26.6.1",
+                "jest-runtime": "^26.6.1",
+                "jest-snapshot": "^26.6.1",
+                "jest-util": "^26.6.1",
+                "pretty-format": "^26.6.1",
+                "throat": "^5.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "jest-leak-detector": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.6.1.tgz",
+            "integrity": "sha512-j9ZOtJSJKlHjrs4aIxWjiQUjyrffPdiAQn2Iw0916w7qZE5Lk0T2KhIH6E9vfhzP6sw0Q0jtnLLb4vQ71o1HlA==",
+            "dev": true,
+            "requires": {
+                "jest-get-type": "^26.3.0",
+                "pretty-format": "^26.6.1"
+            }
+        },
+        "jest-matcher-utils": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.6.1.tgz",
+            "integrity": "sha512-9iu3zrsYlUnl8pByhREF9rr5eYoiEb1F7ymNKg6lJr/0qD37LWS5FSW/JcoDl8UdMX2+zAzabDs7sTO+QFKjCg==",
+            "dev": true,
+            "requires": {
+                "chalk": "^4.0.0",
+                "jest-diff": "^26.6.1",
+                "jest-get-type": "^26.3.0",
+                "pretty-format": "^26.6.1"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "jest-message-util": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.6.1.tgz",
+            "integrity": "sha512-cqM4HnqncIebBNdTKrBoWR/4ufHTll0pK/FWwX0YasK+TlBQEMqw3IEdynuuOTjDPFO3ONlFn37280X48beByw==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@jest/types": "^26.6.1",
+                "@types/stack-utils": "^2.0.0",
+                "chalk": "^4.0.0",
+                "graceful-fs": "^4.2.4",
+                "micromatch": "^4.0.2",
+                "slash": "^3.0.0",
+                "stack-utils": "^2.0.2"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "slash": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+                    "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "jest-mock": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.6.1.tgz",
+            "integrity": "sha512-my0lPTBu1awY8iVG62sB2sx9qf8zxNDVX+5aFgoB8Vbqjb6LqIOsfyFA8P1z6H2IsqMbvOX9oCJnK67Y3yUIMA==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.6.1",
+                "@types/node": "*"
+            }
+        },
+        "jest-pnp-resolver": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
+            "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
+            "dev": true
+        },
         "jest-regex-util": {
             "version": "26.0.0",
             "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-26.0.0.tgz",
             "integrity": "sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==",
             "dev": true
+        },
+        "jest-resolve": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.6.1.tgz",
+            "integrity": "sha512-hiHfQH6rrcpAmw9xCQ0vD66SDuU+7ZulOuKwc4jpbmFFsz0bQG/Ib92K+9/489u5rVw0btr/ZhiHqBpmkbCvuQ==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.6.1",
+                "chalk": "^4.0.0",
+                "graceful-fs": "^4.2.4",
+                "jest-pnp-resolver": "^1.2.2",
+                "jest-util": "^26.6.1",
+                "read-pkg-up": "^7.0.1",
+                "resolve": "^1.18.1",
+                "slash": "^3.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "read-pkg": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+                    "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/normalize-package-data": "^2.4.0",
+                        "normalize-package-data": "^2.5.0",
+                        "parse-json": "^5.0.0",
+                        "type-fest": "^0.6.0"
+                    },
+                    "dependencies": {
+                        "type-fest": {
+                            "version": "0.6.0",
+                            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+                            "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+                            "dev": true
+                        }
+                    }
+                },
+                "read-pkg-up": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+                    "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^4.1.0",
+                        "read-pkg": "^5.2.0",
+                        "type-fest": "^0.8.1"
+                    }
+                },
+                "slash": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+                    "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "jest-resolve-dependencies": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.6.1.tgz",
+            "integrity": "sha512-MN6lufbZJ3RBfTnJesZtHu3hUCBqPdHRe2+FhIt0yiqJ3fMgzWRqMRQyN/d/QwOE7KXwAG2ekZutbPhuD7s51A==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.6.1",
+                "jest-regex-util": "^26.0.0",
+                "jest-snapshot": "^26.6.1"
+            }
+        },
+        "jest-runner": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.6.1.tgz",
+            "integrity": "sha512-DmpNGdgsbl5s0FGkmsInmqnmqCtliCSnjWA2TFAJS1m1mL5atwfPsf+uoZ8uYQ2X0uDj4NM+nPcDnUpbNTRMBA==",
+            "dev": true,
+            "requires": {
+                "@jest/console": "^26.6.1",
+                "@jest/environment": "^26.6.1",
+                "@jest/test-result": "^26.6.1",
+                "@jest/types": "^26.6.1",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "emittery": "^0.7.1",
+                "exit": "^0.1.2",
+                "graceful-fs": "^4.2.4",
+                "jest-config": "^26.6.1",
+                "jest-docblock": "^26.0.0",
+                "jest-haste-map": "^26.6.1",
+                "jest-leak-detector": "^26.6.1",
+                "jest-message-util": "^26.6.1",
+                "jest-resolve": "^26.6.1",
+                "jest-runtime": "^26.6.1",
+                "jest-util": "^26.6.1",
+                "jest-worker": "^26.6.1",
+                "source-map-support": "^0.5.6",
+                "throat": "^5.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "jest-runtime": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.1.tgz",
+            "integrity": "sha512-7uOCNeezXDWgjEyzYbRN2ViY7xNZzusNVGAMmU0UHRUNXuY4j4GBHKGMqPo/cBPZA9bSYp+lwK2DRRBU5Dv6YQ==",
+            "dev": true,
+            "requires": {
+                "@jest/console": "^26.6.1",
+                "@jest/environment": "^26.6.1",
+                "@jest/fake-timers": "^26.6.1",
+                "@jest/globals": "^26.6.1",
+                "@jest/source-map": "^26.5.0",
+                "@jest/test-result": "^26.6.1",
+                "@jest/transform": "^26.6.1",
+                "@jest/types": "^26.6.1",
+                "@types/yargs": "^15.0.0",
+                "chalk": "^4.0.0",
+                "cjs-module-lexer": "^0.4.2",
+                "collect-v8-coverage": "^1.0.0",
+                "exit": "^0.1.2",
+                "glob": "^7.1.3",
+                "graceful-fs": "^4.2.4",
+                "jest-config": "^26.6.1",
+                "jest-haste-map": "^26.6.1",
+                "jest-message-util": "^26.6.1",
+                "jest-mock": "^26.6.1",
+                "jest-regex-util": "^26.0.0",
+                "jest-resolve": "^26.6.1",
+                "jest-snapshot": "^26.6.1",
+                "jest-util": "^26.6.1",
+                "jest-validate": "^26.6.1",
+                "slash": "^3.0.0",
+                "strip-bom": "^4.0.0",
+                "yargs": "^15.4.1"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "slash": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+                    "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+                    "dev": true
+                },
+                "strip-bom": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+                    "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
         },
         "jest-serializer": {
             "version": "26.5.0",
@@ -9671,13 +11546,94 @@
                 "graceful-fs": "^4.2.4"
             }
         },
-        "jest-util": {
-            "version": "26.5.2",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.2.tgz",
-            "integrity": "sha512-WTL675bK+GSSAYgS8z9FWdCT2nccO1yTIplNLPlP0OD8tUk/H5IrWKMMRudIQQ0qp8bb4k+1Qa8CxGKq9qnYdg==",
+        "jest-snapshot": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.1.tgz",
+            "integrity": "sha512-JA7bZp7HRTIJYAi85pJ/OZ2eur2dqmwIToA5/6d7Mn90isGEfeF9FvuhDLLEczgKP1ihreBzrJ6Vr7zteP5JNA==",
             "dev": true,
             "requires": {
-                "@jest/types": "^26.5.2",
+                "@babel/types": "^7.0.0",
+                "@jest/types": "^26.6.1",
+                "@types/babel__traverse": "^7.0.4",
+                "@types/prettier": "^2.0.0",
+                "chalk": "^4.0.0",
+                "expect": "^26.6.1",
+                "graceful-fs": "^4.2.4",
+                "jest-diff": "^26.6.1",
+                "jest-get-type": "^26.3.0",
+                "jest-haste-map": "^26.6.1",
+                "jest-matcher-utils": "^26.6.1",
+                "jest-message-util": "^26.6.1",
+                "jest-resolve": "^26.6.1",
+                "natural-compare": "^1.4.0",
+                "pretty-format": "^26.6.1",
+                "semver": "^7.3.2"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "7.3.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+                    "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "jest-util": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.1.tgz",
+            "integrity": "sha512-xCLZUqVoqhquyPLuDXmH7ogceGctbW8SMyQVjD9o+1+NPWI7t0vO08udcFLVPLgKWcvc+zotaUv/RuaR6l8HIA==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.6.1",
                 "@types/node": "*",
                 "chalk": "^4.0.0",
                 "graceful-fs": "^4.2.4",
@@ -9736,10 +11692,147 @@
                 }
             }
         },
+        "jest-validate": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.6.1.tgz",
+            "integrity": "sha512-BEFpGbylKocnNPZULcnk+TGaz1oFZQH/wcaXlaXABbu0zBwkOGczuWgdLucUouuQqn7VadHZZeTvo8VSFDLMOA==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.6.1",
+                "camelcase": "^6.0.0",
+                "chalk": "^4.0.0",
+                "jest-get-type": "^26.3.0",
+                "leven": "^3.1.0",
+                "pretty-format": "^26.6.1"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "camelcase": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.1.0.tgz",
+                    "integrity": "sha512-WCMml9ivU60+8rEJgELlFp1gxFcEGxwYleE3bziHEDeqsqAWGHdimB7beBFGjLzVNgPGyDsfgXLQEYMpmIFnVQ==",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "jest-watcher": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.6.1.tgz",
+            "integrity": "sha512-0LBIPPncNi9CaLKK15bnxyd2E8OMl4kJg0PTiNOI+MXztXw1zVdtX/x9Pr6pXaQYps+eS/ts43O4+HByZ7yJSw==",
+            "dev": true,
+            "requires": {
+                "@jest/test-result": "^26.6.1",
+                "@jest/types": "^26.6.1",
+                "@types/node": "*",
+                "ansi-escapes": "^4.2.1",
+                "chalk": "^4.0.0",
+                "jest-util": "^26.6.1",
+                "string-length": "^4.0.1"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
         "jest-worker": {
-            "version": "26.3.0",
-            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.3.0.tgz",
-            "integrity": "sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==",
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.1.tgz",
+            "integrity": "sha512-R5IE3qSGz+QynJx8y+ICEkdI2OJ3RJjRQVEyCcFAd3yVhQSEtquziPO29Mlzgn07LOVE8u8jhJ1FqcwegiXWOw==",
             "requires": {
                 "@types/node": "*",
                 "merge-stream": "^2.0.0",
@@ -9781,6 +11874,60 @@
                 "esprima": "^4.0.0"
             }
         },
+        "jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+            "dev": true
+        },
+        "jsdom": {
+            "version": "16.4.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.4.0.tgz",
+            "integrity": "sha512-lYMm3wYdgPhrl7pDcRmvzPhhrGVBeVhPIqeHjzeiHN3DFmD1RBpbExbi8vU7BJdH8VAZYovR8DMt0PNNDM7k8w==",
+            "dev": true,
+            "requires": {
+                "abab": "^2.0.3",
+                "acorn": "^7.1.1",
+                "acorn-globals": "^6.0.0",
+                "cssom": "^0.4.4",
+                "cssstyle": "^2.2.0",
+                "data-urls": "^2.0.0",
+                "decimal.js": "^10.2.0",
+                "domexception": "^2.0.1",
+                "escodegen": "^1.14.1",
+                "html-encoding-sniffer": "^2.0.1",
+                "is-potential-custom-element-name": "^1.0.0",
+                "nwsapi": "^2.2.0",
+                "parse5": "5.1.1",
+                "request": "^2.88.2",
+                "request-promise-native": "^1.0.8",
+                "saxes": "^5.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^3.0.1",
+                "w3c-hr-time": "^1.0.2",
+                "w3c-xmlserializer": "^2.0.0",
+                "webidl-conversions": "^6.1.0",
+                "whatwg-encoding": "^1.0.5",
+                "whatwg-mimetype": "^2.3.0",
+                "whatwg-url": "^8.0.0",
+                "ws": "^7.2.3",
+                "xml-name-validator": "^3.0.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "7.4.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+                    "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+                    "dev": true
+                },
+                "parse5": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+                    "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+                    "dev": true
+                }
+            }
+        },
         "jsesc": {
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -9796,6 +11943,12 @@
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
         },
+        "json-schema": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+            "dev": true
+        },
         "json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -9805,6 +11958,12 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+            "dev": true
+        },
+        "json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
             "dev": true
         },
         "json5": {
@@ -9821,6 +11980,18 @@
             "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
             "requires": {
                 "graceful-fs": "^4.1.6"
+            }
+        },
+        "jsprim": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
             }
         },
         "jsx-ast-utils": {
@@ -9845,6 +12016,12 @@
             "requires": {
                 "graceful-fs": "^4.1.9"
             }
+        },
+        "kleur": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+            "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+            "dev": true
         },
         "language-subtag-registry": {
             "version": "0.3.20",
@@ -9888,15 +12065,8 @@
         "leven": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
-            "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="
-        },
-        "levenary": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/levenary/-/levenary-1.1.1.tgz",
-            "integrity": "sha512-mkAdOIt79FD6irqjYSs4rdbnlT5vRonMEvBVPVb3XmevfS8kgRXwfes0dhPdEtzTWD/1eNE/Bm/G1iRt6DcnQQ==",
-            "requires": {
-                "leven": "^3.1.0"
-            }
+            "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+            "dev": true
         },
         "levn": {
             "version": "0.3.0",
@@ -9948,13 +12118,23 @@
             "integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw=="
         },
         "loader-utils": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-            "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+            "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
             "requires": {
                 "big.js": "^5.2.2",
                 "emojis-list": "^3.0.0",
-                "json5": "^2.1.2"
+                "json5": "^1.0.1"
+            },
+            "dependencies": {
+                "json5": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+                    "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+                    "requires": {
+                        "minimist": "^1.2.0"
+                    }
+                }
             }
         },
         "locate-path": {
@@ -9974,6 +12154,18 @@
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
             "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+        },
+        "lodash.memoize": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+            "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+            "dev": true
+        },
+        "lodash.sortby": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+            "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+            "dev": true
         },
         "lodash.throttle": {
             "version": "4.1.1",
@@ -10051,6 +12243,12 @@
                     "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
                 }
             }
+        },
+        "make-error": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+            "dev": true
         },
         "makeerror": {
             "version": "1.0.11",
@@ -10244,6 +12442,37 @@
             "requires": {
                 "braces": "^3.0.1",
                 "picomatch": "^2.0.5"
+            },
+            "dependencies": {
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                }
             }
         },
         "miller-rabin": {
@@ -10445,12 +12674,6 @@
             "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
             "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
         },
-        "nan": {
-            "version": "2.14.1",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-            "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
-            "optional": true
-        },
         "nanomatch": {
             "version": "1.2.13",
             "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -10566,10 +12789,41 @@
             "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
             "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA="
         },
+        "node-notifier": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.0.tgz",
+            "integrity": "sha512-46z7DUmcjoYdaWyXouuFNNfUo6eFa94t23c53c+lG/9Cvauk4a98rAUp9672X5dxGdQmLpPzTxzu8f/OeEPaFA==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "growly": "^1.3.0",
+                "is-wsl": "^2.2.0",
+                "semver": "^7.3.2",
+                "shellwords": "^0.1.1",
+                "uuid": "^8.3.0",
+                "which": "^2.0.2"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "7.3.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+                    "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+                    "dev": true,
+                    "optional": true
+                },
+                "uuid": {
+                    "version": "8.3.1",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+                    "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
         "node-releases": {
-            "version": "1.1.61",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.61.tgz",
-            "integrity": "sha512-DD5vebQLg8jLCOzwupn954fbIiZht05DAZs0k2u8NStSe6h9XdsuIQL8hSRKYiU8WUQRznmSDrKGbv3ObOmC7g=="
+            "version": "1.1.64",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.64.tgz",
+            "integrity": "sha512-Iec8O9166/x2HRMJyLLLWkd0sFFLrFNy+Xf+JQfSQsdBJzPcHpNl3JQ9gD4j+aJxmCa25jNsIbM4bmACtSbkSg=="
         },
         "normalize-package-data": {
             "version": "2.5.0",
@@ -10608,6 +12862,14 @@
             "dev": true,
             "requires": {
                 "path-key": "^2.0.0"
+            },
+            "dependencies": {
+                "path-key": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+                    "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+                    "dev": true
+                }
             }
         },
         "npmlog": {
@@ -10638,6 +12900,18 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+        },
+        "nwsapi": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
+            "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
+            "dev": true
+        },
+        "oauth-sign": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+            "dev": true
         },
         "object-assign": {
             "version": "4.1.1",
@@ -10678,12 +12952,12 @@
             "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
         },
         "object-is": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
-            "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.3.tgz",
+            "integrity": "sha512-teyqLvFWzLkq5B9ki8FVWA902UER2qkxmdA4nLf+wjOLAWgxzCWZNCxpDq9MvE8MmhWNr+I8w3BN49Vx36Y6Xg==",
             "requires": {
                 "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.5"
+                "es-abstract": "^1.18.0-next.1"
             }
         },
         "object-keys": {
@@ -10715,27 +12989,6 @@
                 "es-abstract": "^1.18.0-next.0",
                 "has-symbols": "^1.0.1",
                 "object-keys": "^1.1.1"
-            },
-            "dependencies": {
-                "es-abstract": {
-                    "version": "1.18.0-next.0",
-                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.0.tgz",
-                    "integrity": "sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==",
-                    "requires": {
-                        "es-to-primitive": "^1.2.1",
-                        "function-bind": "^1.1.1",
-                        "has": "^1.0.3",
-                        "has-symbols": "^1.0.1",
-                        "is-callable": "^1.2.0",
-                        "is-negative-zero": "^2.0.0",
-                        "is-regex": "^1.1.1",
-                        "object-inspect": "^1.8.0",
-                        "object-keys": "^1.1.1",
-                        "object.assign": "^4.1.0",
-                        "string.prototype.trimend": "^1.0.1",
-                        "string.prototype.trimstart": "^1.0.1"
-                    }
-                }
             }
         },
         "object.entries": {
@@ -10746,6 +12999,26 @@
                 "define-properties": "^1.1.3",
                 "es-abstract": "^1.17.5",
                 "has": "^1.0.3"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                }
             }
         },
         "object.fromentries": {
@@ -10757,6 +13030,26 @@
                 "es-abstract": "^1.17.0-next.1",
                 "function-bind": "^1.1.1",
                 "has": "^1.0.3"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                }
             }
         },
         "object.getownpropertydescriptors": {
@@ -10766,6 +13059,26 @@
             "requires": {
                 "define-properties": "^1.1.3",
                 "es-abstract": "^1.17.0-next.1"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                }
             }
         },
         "object.pick": {
@@ -10792,6 +13105,26 @@
                 "es-abstract": "^1.17.0-next.1",
                 "function-bind": "^1.1.1",
                 "has": "^1.0.3"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                }
             }
         },
         "objectorarray": {
@@ -10866,6 +13199,12 @@
             "version": "1.13.0",
             "resolved": "https://registry.npmjs.org/overlayscrollbars/-/overlayscrollbars-1.13.0.tgz",
             "integrity": "sha512-p8oHrMeRAKxXDMPI/EBNITj/zTVHKNnAnM59Im+xnoZUlV07FyTg46wom2286jJlXGGfcPFG/ba5NUiCwWNd4w=="
+        },
+        "p-each-series": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz",
+            "integrity": "sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ==",
+            "dev": true
         },
         "p-finally": {
             "version": "1.0.0",
@@ -11016,10 +13355,9 @@
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "path-key": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-            "dev": true
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
         },
         "path-parse": {
             "version": "1.0.6",
@@ -11243,24 +13581,6 @@
                 "schema-utils": "^1.0.0"
             },
             "dependencies": {
-                "json5": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-                    "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-                    "requires": {
-                        "minimist": "^1.2.0"
-                    }
-                },
-                "loader-utils": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-                    "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-                    "requires": {
-                        "big.js": "^5.2.2",
-                        "emojis-list": "^3.0.0",
-                        "json5": "^1.0.1"
-                    }
-                },
                 "schema-utils": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
@@ -11339,12 +13659,62 @@
             "dev": true
         },
         "pretty-error": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
-            "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.2.tgz",
+            "integrity": "sha512-EY5oDzmsX5wvuynAByrmY0P0hcp+QpnAKbJng2A2MPjVKXCxrDSUkzghVJ4ZGPIv+JC4gX8fPUWscC0RtjsWGw==",
             "requires": {
-                "renderkid": "^2.0.1",
-                "utila": "~0.4"
+                "lodash": "^4.17.20",
+                "renderkid": "^2.0.4"
+            }
+        },
+        "pretty-format": {
+            "version": "26.6.1",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.1.tgz",
+            "integrity": "sha512-MeqqsP5PYcRBbGMvwzsyBdmAJ4EFX7pWFyl7x4+dMVg5pE0ZDdBIvEH2ergvIO+Gvwv1wh64YuOY9y5LuyY/GA==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^26.6.1",
+                "ansi-regex": "^5.0.0",
+                "ansi-styles": "^4.0.0",
+                "react-is": "^17.0.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "react-is": {
+                    "version": "17.0.1",
+                    "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+                    "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
+                    "dev": true
+                }
             }
         },
         "pretty-hrtime": {
@@ -11353,17 +13723,12 @@
             "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE="
         },
         "prismjs": {
-            "version": "1.21.0",
-            "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
-            "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
+            "version": "1.22.0",
+            "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.22.0.tgz",
+            "integrity": "sha512-lLJ/Wt9yy0AiSYBf212kK3mM5L8ycwlyTlSxHBAneXLR0nzFMlZ5y7riFPF3E33zXOF2IH95xdY5jIyZbM9z/w==",
             "requires": {
                 "clipboard": "^2.0.0"
             }
-        },
-        "private": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-            "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
         },
         "process": {
             "version": "0.11.10",
@@ -11396,6 +13761,26 @@
                 "es-abstract": "^1.17.0-next.1",
                 "function-bind": "^1.1.1",
                 "iterate-value": "^1.0.0"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                }
             }
         },
         "promise.prototype.finally": {
@@ -11406,6 +13791,36 @@
                 "define-properties": "^1.1.3",
                 "es-abstract": "^1.17.0-next.0",
                 "function-bind": "^1.1.1"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "prompts": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
+            "integrity": "sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==",
+            "dev": true,
+            "requires": {
+                "kleur": "^3.0.3",
+                "sisteransi": "^1.0.4"
             }
         },
         "prop-types": {
@@ -11419,9 +13834,9 @@
             }
         },
         "property-information": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.5.0.tgz",
-            "integrity": "sha512-RgEbCx2HLa1chNgvChcx+rrCWD0ctBmGSE0M7lVm1yyv4UbvbrWoXp/BkVLZefzjrRBGW8/Js6uh/BnlHXFyjA==",
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
+            "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
             "requires": {
                 "xtend": "^4.0.0"
             }
@@ -11439,6 +13854,12 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
             "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+        },
+        "psl": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+            "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+            "dev": true
         },
         "public-encrypt": {
             "version": "4.0.3",
@@ -11567,18 +13988,40 @@
             }
         },
         "raw-loader": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-4.0.1.tgz",
-            "integrity": "sha512-baolhQBSi3iNh1cglJjA0mYzga+wePk7vdEX//1dTFd+v4TsQlQE0jitJSNF1OIP82rdYulH7otaVmdlDaJ64A==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-4.0.2.tgz",
+            "integrity": "sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==",
             "requires": {
                 "loader-utils": "^2.0.0",
-                "schema-utils": "^2.6.5"
+                "schema-utils": "^3.0.0"
+            },
+            "dependencies": {
+                "loader-utils": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+                    "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+                    "requires": {
+                        "big.js": "^5.2.2",
+                        "emojis-list": "^3.0.0",
+                        "json5": "^2.1.2"
+                    }
+                },
+                "schema-utils": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+                    "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
+                    "requires": {
+                        "@types/json-schema": "^7.0.6",
+                        "ajv": "^6.12.5",
+                        "ajv-keywords": "^3.5.2"
+                    }
+                }
             }
         },
         "react": {
-            "version": "16.13.1",
-            "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
-            "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
+            "version": "16.14.0",
+            "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+            "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
             "requires": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1",
@@ -11656,33 +14099,6 @@
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
                     "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
                 },
-                "braces": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-                    "requires": {
-                        "arr-flatten": "^1.1.0",
-                        "array-unique": "^0.3.2",
-                        "extend-shallow": "^2.0.1",
-                        "fill-range": "^4.0.0",
-                        "isobject": "^3.0.1",
-                        "repeat-element": "^1.1.2",
-                        "snapdragon": "^0.8.1",
-                        "snapdragon-node": "^2.0.1",
-                        "split-string": "^3.0.2",
-                        "to-regex": "^3.0.1"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
                 "browserslist": {
                     "version": "4.10.0",
                     "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.10.0.tgz",
@@ -11698,16 +14114,6 @@
                     "version": "2.2.1",
                     "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
                     "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw=="
-                },
-                "cross-spawn": {
-                    "version": "7.0.1",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
-                    "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
-                    "requires": {
-                        "path-key": "^3.1.0",
-                        "shebang-command": "^2.0.0",
-                        "which": "^2.0.1"
-                    }
                 },
                 "debug": {
                     "version": "2.6.9",
@@ -11740,27 +14146,6 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
                     "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
-                },
-                "fill-range": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-                    "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1",
-                        "to-regex-range": "^2.1.0"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
                 },
                 "fork-ts-checker-webpack-plugin": {
                     "version": "3.1.1",
@@ -11817,29 +14202,6 @@
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
                     "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
                 },
-                "is-number": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
-                    }
-                },
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-                },
                 "json5": {
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
@@ -11883,28 +14245,10 @@
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                     "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 },
-                "path-key": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-                    "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
-                },
                 "semver": {
                     "version": "5.7.1",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                     "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                },
-                "shebang-command": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-                    "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-                    "requires": {
-                        "shebang-regex": "^3.0.0"
-                    }
-                },
-                "shebang-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-                    "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
                 },
                 "string-width": {
                     "version": "4.2.0",
@@ -11923,34 +14267,17 @@
                     "requires": {
                         "ansi-regex": "^5.0.0"
                     }
-                },
-                "to-regex-range": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-                    "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-                    "requires": {
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1"
-                    }
-                },
-                "which": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-                    "requires": {
-                        "isexe": "^2.0.0"
-                    }
                 }
             }
         },
         "react-docgen": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-5.3.0.tgz",
-            "integrity": "sha512-hUrv69k6nxazOuOmdGeOpC/ldiKy7Qj/UFpxaQi0eDMrUFUTIPGtY5HJu7BggSmiyAMfREaESbtBL9UzdQ+hyg==",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-5.3.1.tgz",
+            "integrity": "sha512-YG7YujVTwlLslr2Ny8nQiUfbBuEwKsLHJdQTSdEga1eY/nRFh/7LjCWUn6ogYhu2WDKg4z+6W/BJtUi+DPUIlA==",
             "requires": {
                 "@babel/core": "^7.7.5",
                 "@babel/runtime": "^7.7.6",
-                "ast-types": "^0.13.2",
+                "ast-types": "^0.14.2",
                 "commander": "^2.19.0",
                 "doctrine": "^3.0.0",
                 "neo-async": "^2.6.1",
@@ -11978,26 +14305,6 @@
                 "@webpack-contrib/schema-utils": "^1.0.0-beta.0",
                 "loader-utils": "^1.2.3",
                 "react-docgen-typescript": "^1.15.0"
-            },
-            "dependencies": {
-                "json5": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-                    "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-                    "requires": {
-                        "minimist": "^1.2.0"
-                    }
-                },
-                "loader-utils": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-                    "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-                    "requires": {
-                        "big.js": "^5.2.2",
-                        "emojis-list": "^3.0.0",
-                        "json5": "^1.0.1"
-                    }
-                }
             }
         },
         "react-docgen-typescript-plugin": {
@@ -12014,16 +14321,16 @@
             },
             "dependencies": {
                 "tslib": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
-                    "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+                    "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
                 }
             }
         },
         "react-dom": {
-            "version": "16.13.1",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
-            "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
+            "version": "16.14.0",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+            "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
             "requires": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1",
@@ -12062,9 +14369,9 @@
             }
         },
         "react-error-overlay": {
-            "version": "6.0.7",
-            "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.7.tgz",
-            "integrity": "sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA=="
+            "version": "6.0.8",
+            "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.8.tgz",
+            "integrity": "sha512-HvPuUQnLp5H7TouGq3kzBeioJmXms1wHy9EGjz2OURWBp4qZO6AfGEcnxts1D/CbwPLRAgTMPCEgYhA3sEM4vw=="
         },
         "react-fast-compare": {
             "version": "3.2.0",
@@ -12092,12 +14399,12 @@
             }
         },
         "react-image-crop": {
-            "version": "8.6.5",
-            "resolved": "https://registry.npmjs.org/react-image-crop/-/react-image-crop-8.6.5.tgz",
-            "integrity": "sha512-IbcB8rPWZRClLfJjsB9de4sa7EwoLGnGSQH8BP+pay5uKkvulY6y3L4BGKhcckOt0NnTdUNAkeKICl9yH3wXuA==",
+            "version": "8.6.6",
+            "resolved": "https://registry.npmjs.org/react-image-crop/-/react-image-crop-8.6.6.tgz",
+            "integrity": "sha512-2iQHKp12dYb6Fu2iN/Mg19BeLMgrbdOuKkU9k0RH7CHX6ZZylOlhfCM3/RsECbKnjGJRtGpXniGF+/i9CGis1A==",
             "requires": {
-                "clsx": "^1.0.4",
-                "core-js": "^3.4.2",
+                "clsx": "^1.1.1",
+                "core-js": "^3.6.5",
                 "prop-types": "^15.7.2"
             }
         },
@@ -12384,34 +14691,11 @@
             }
         },
         "readdirp": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
-            "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+            "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
             "requires": {
                 "picomatch": "^2.2.1"
-            }
-        },
-        "recast": {
-            "version": "0.14.7",
-            "resolved": "https://registry.npmjs.org/recast/-/recast-0.14.7.tgz",
-            "integrity": "sha512-/nwm9pkrcWagN40JeJhkPaRxiHXBRkXyRh/hgU088Z/v+qCy+zIHHY6bC6o7NaKAxPqtE6nD8zBH1LfU0/Wx6A==",
-            "requires": {
-                "ast-types": "0.11.3",
-                "esprima": "~4.0.0",
-                "private": "~0.1.5",
-                "source-map": "~0.6.1"
-            },
-            "dependencies": {
-                "ast-types": {
-                    "version": "0.11.3",
-                    "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.3.tgz",
-                    "integrity": "sha512-XA5o5dsNw8MhyW0Q7MWXJWc4oOzZKbdsEJq45h7c8q/d9DwWZ5F2ugUc1PuMLPGsUnphCt/cNDHu8JeBbxf1qA=="
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-                }
             }
         },
         "recharts": {
@@ -12559,6 +14843,26 @@
             "requires": {
                 "define-properties": "^1.1.3",
                 "es-abstract": "^1.17.0-next.1"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                }
             }
         },
         "regexpp": {
@@ -12635,19 +14939,71 @@
             "dev": true
         },
         "remark-mdx": {
-            "version": "1.6.18",
-            "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-1.6.18.tgz",
-            "integrity": "sha512-xNhjv4kJZ8L6RV68yK8fQ6XWlvSIFOE5VPmM7wMKSwkvwBu6tlUJy0gRF2WiZ4fPPOj6jpqlVB9QakipvZuEqg==",
+            "version": "1.6.19",
+            "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-1.6.19.tgz",
+            "integrity": "sha512-UKK1CFatVPNhgjsIlNQ3GjVl3+6O7x7Hag6oyntFTg8s7sgq+rhWaSfM/6lW5UWU6hzkj520KYBuBlsaSriGtA==",
             "dev": true,
             "requires": {
                 "@babel/core": "7.11.6",
                 "@babel/helper-plugin-utils": "7.10.4",
                 "@babel/plugin-proposal-object-rest-spread": "7.11.0",
                 "@babel/plugin-syntax-jsx": "7.10.4",
-                "@mdx-js/util": "1.6.18",
+                "@mdx-js/util": "1.6.19",
                 "is-alphabetical": "1.0.4",
                 "remark-parse": "8.0.3",
                 "unified": "9.2.0"
+            },
+            "dependencies": {
+                "@babel/core": {
+                    "version": "7.11.6",
+                    "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
+                    "integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.10.4",
+                        "@babel/generator": "^7.11.6",
+                        "@babel/helper-module-transforms": "^7.11.0",
+                        "@babel/helpers": "^7.10.4",
+                        "@babel/parser": "^7.11.5",
+                        "@babel/template": "^7.10.4",
+                        "@babel/traverse": "^7.11.5",
+                        "@babel/types": "^7.11.5",
+                        "convert-source-map": "^1.7.0",
+                        "debug": "^4.1.0",
+                        "gensync": "^1.0.0-beta.1",
+                        "json5": "^2.1.2",
+                        "lodash": "^4.17.19",
+                        "resolve": "^1.3.2",
+                        "semver": "^5.4.1",
+                        "source-map": "^0.5.0"
+                    }
+                },
+                "@babel/plugin-proposal-object-rest-spread": {
+                    "version": "7.11.0",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.11.0.tgz",
+                    "integrity": "sha512-wzch41N4yztwoRw0ak+37wxwJM2oiIiy6huGCoqkvSTA9acYWcPfn9Y4aJqmFFJ70KTJUu29f3DQ43uJ9HXzEA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.10.4",
+                        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+                        "@babel/plugin-transform-parameters": "^7.10.4"
+                    }
+                },
+                "@babel/plugin-syntax-jsx": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.10.4.tgz",
+                    "integrity": "sha512-KCg9mio9jwiARCB7WAcQ7Y1q+qicILjoK8LP/VkPkEKaf5dkaZZK1EcTe91a3JJlZ3qy6L5s9X52boEYi8DM9g==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.10.4"
+                    }
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
+                }
             }
         },
         "remark-parse": {
@@ -12716,15 +15072,15 @@
             "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
         },
         "renderkid": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.3.tgz",
-            "integrity": "sha512-z8CLQp7EZBPCwCnncgf9C4XAi3WR0dv+uWu/PjIyhhAb5d6IJ/QZqlHFprHeKT+59//V6BNUsLbvN8+2LarxGA==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.4.tgz",
+            "integrity": "sha512-K2eXrSOJdq+HuKzlcjOlGoOarUu5SDguDEhE7+Ah4zuOWL40j8A/oHvLlLob9PSTNvVnBd+/q0Er1QfpEuem5g==",
             "requires": {
                 "css-select": "^1.1.0",
                 "dom-converter": "^0.2",
                 "htmlparser2": "^3.3.0",
-                "strip-ansi": "^3.0.0",
-                "utila": "^0.4.0"
+                "lodash": "^4.17.20",
+                "strip-ansi": "^3.0.0"
             }
         },
         "repeat-element": {
@@ -12743,6 +15099,107 @@
             "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
             "dev": true
         },
+        "request": {
+            "version": "2.88.2",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+            "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+            "dev": true,
+            "requires": {
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.3",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.5.0",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
+            },
+            "dependencies": {
+                "form-data": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+                    "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+                    "dev": true,
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.6",
+                        "mime-types": "^2.1.12"
+                    }
+                },
+                "qs": {
+                    "version": "6.5.2",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+                    "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+                    "dev": true
+                },
+                "tough-cookie": {
+                    "version": "2.5.0",
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+                    "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+                    "dev": true,
+                    "requires": {
+                        "psl": "^1.1.28",
+                        "punycode": "^2.1.1"
+                    }
+                }
+            }
+        },
+        "request-promise-core": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+            "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.19"
+            }
+        },
+        "request-promise-native": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+            "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
+            "dev": true,
+            "requires": {
+                "request-promise-core": "1.1.4",
+                "stealthy-require": "^1.1.1",
+                "tough-cookie": "^2.3.3"
+            },
+            "dependencies": {
+                "tough-cookie": {
+                    "version": "2.5.0",
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+                    "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+                    "dev": true,
+                    "requires": {
+                        "psl": "^1.1.28",
+                        "punycode": "^2.1.1"
+                    }
+                }
+            }
+        },
+        "require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "dev": true
+        },
+        "require-main-filename": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+            "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+            "dev": true
+        },
         "reselect": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
@@ -12755,11 +15212,21 @@
             "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
         },
         "resolve": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-            "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+            "version": "1.18.1",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
+            "integrity": "sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==",
             "requires": {
+                "is-core-module": "^2.0.0",
                 "path-parse": "^1.0.6"
+            }
+        },
+        "resolve-cwd": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+            "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+            "dev": true,
+            "requires": {
+                "resolve-from": "^5.0.0"
             }
         },
         "resolve-from": {
@@ -12885,84 +15352,6 @@
                         "normalize-path": "^2.1.1"
                     }
                 },
-                "braces": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-                    "dev": true,
-                    "requires": {
-                        "arr-flatten": "^1.1.0",
-                        "array-unique": "^0.3.2",
-                        "extend-shallow": "^2.0.1",
-                        "fill-range": "^4.0.0",
-                        "isobject": "^3.0.1",
-                        "repeat-element": "^1.1.2",
-                        "snapdragon": "^0.8.1",
-                        "snapdragon-node": "^2.0.1",
-                        "split-string": "^3.0.2",
-                        "to-regex": "^3.0.1"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "dev": true,
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "fill-range": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-                    "dev": true,
-                    "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1",
-                        "to-regex-range": "^2.1.0"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "dev": true,
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "is-number": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "dev": true,
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
-                    }
-                },
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
-                },
                 "micromatch": {
                     "version": "3.1.10",
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -12992,16 +15381,6 @@
                     "requires": {
                         "remove-trailing-separator": "^1.0.1"
                     }
-                },
-                "to-regex-range": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-                    "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-                    "dev": true,
-                    "requires": {
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1"
-                    }
                 }
             }
         },
@@ -13009,6 +15388,15 @@
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
             "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+        },
+        "saxes": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+            "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+            "dev": true,
+            "requires": {
+                "xmlchars": "^2.2.0"
+            }
         },
         "scheduler": {
             "version": "0.19.1",
@@ -13209,19 +15597,17 @@
             "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
         },
         "shebang-command": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-            "dev": true,
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
             "requires": {
-                "shebang-regex": "^1.0.0"
+                "shebang-regex": "^3.0.0"
             }
         },
         "shebang-regex": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-            "dev": true
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
         },
         "shell-quote": {
             "version": "1.7.2",
@@ -13245,6 +15631,13 @@
                 }
             }
         },
+        "shellwords": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+            "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+            "dev": true,
+            "optional": true
+        },
         "side-channel": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.3.tgz",
@@ -13252,27 +15645,6 @@
             "requires": {
                 "es-abstract": "^1.18.0-next.0",
                 "object-inspect": "^1.8.0"
-            },
-            "dependencies": {
-                "es-abstract": {
-                    "version": "1.18.0-next.0",
-                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.0.tgz",
-                    "integrity": "sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==",
-                    "requires": {
-                        "es-to-primitive": "^1.2.1",
-                        "function-bind": "^1.1.1",
-                        "has": "^1.0.3",
-                        "has-symbols": "^1.0.1",
-                        "is-callable": "^1.2.0",
-                        "is-negative-zero": "^2.0.0",
-                        "is-regex": "^1.1.1",
-                        "object-inspect": "^1.8.0",
-                        "object-keys": "^1.1.1",
-                        "object.assign": "^4.1.0",
-                        "string.prototype.trimend": "^1.0.1",
-                        "string.prototype.trimstart": "^1.0.1"
-                    }
-                }
             }
         },
         "signal-exit": {
@@ -13280,10 +15652,16 @@
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
             "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
         },
+        "sisteransi": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+            "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+            "dev": true
+        },
         "slash": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+            "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
         },
         "slice-ansi": {
             "version": "2.1.0",
@@ -13512,6 +15890,23 @@
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
         },
+        "sshpk": {
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+            "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+            "dev": true,
+            "requires": {
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
+            }
+        },
         "ssri": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.0.tgz",
@@ -13524,6 +15919,23 @@
             "version": "0.1.8",
             "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
             "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
+        },
+        "stack-utils": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.2.tgz",
+            "integrity": "sha512-0H7QK2ECz3fyZMzQ8rH0j2ykpfbnd20BFtfg/SqVC2+sCTtcw0aDTGB7dk+de4U4uUeuz6nOtJcrkFFLG1B0Rg==",
+            "dev": true,
+            "requires": {
+                "escape-string-regexp": "^2.0.0"
+            },
+            "dependencies": {
+                "escape-string-regexp": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+                    "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+                    "dev": true
+                }
+            }
         },
         "state-toggle": {
             "version": "1.0.3",
@@ -13554,6 +15966,12 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
             "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+        },
+        "stealthy-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+            "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+            "dev": true
         },
         "store2": {
             "version": "2.12.0",
@@ -13595,6 +16013,33 @@
             "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
             "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
         },
+        "string-length": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.1.tgz",
+            "integrity": "sha512-PKyXUd0LK0ePjSOnWn34V2uD6acUWev9uy0Ft05k0E8xRW+SKcA0F7eMr7h5xlzfn+4O3N+55rduYyet3Jk+jw==",
+            "dev": true,
+            "requires": {
+                "char-regex": "^1.0.2",
+                "strip-ansi": "^6.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.0"
+                    }
+                }
+            }
+        },
         "string-width": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -13616,6 +16061,26 @@
                 "internal-slot": "^1.0.2",
                 "regexp.prototype.flags": "^1.3.0",
                 "side-channel": "^1.0.2"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                }
             }
         },
         "string.prototype.padend": {
@@ -13625,6 +16090,26 @@
             "requires": {
                 "define-properties": "^1.1.3",
                 "es-abstract": "^1.17.0-next.1"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                }
             }
         },
         "string.prototype.padstart": {
@@ -13634,24 +16119,44 @@
             "requires": {
                 "define-properties": "^1.1.3",
                 "es-abstract": "^1.17.0-next.1"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                }
             }
         },
         "string.prototype.trimend": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
-            "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.2.tgz",
+            "integrity": "sha512-8oAG/hi14Z4nOVP0z6mdiVZ/wqjDtWSLygMigTzAb+7aPEDTleeFf+WrF+alzecxIRkckkJVn+dTlwzJXORATw==",
             "requires": {
                 "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.5"
+                "es-abstract": "^1.18.0-next.1"
             }
         },
         "string.prototype.trimstart": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
-            "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.2.tgz",
+            "integrity": "sha512-7F6CdBTl5zyu30BJFdzSTlSlLPwODC23Od+iLoVH8X6+3fvDPPuBVVj9iaB1GOsSTSIgVfsfm27R2FGrAPznWg==",
             "requires": {
                 "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.5"
+                "es-abstract": "^1.18.0-next.1"
             }
         },
         "string_decoder": {
@@ -13682,6 +16187,12 @@
             "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
             "dev": true
         },
+        "strip-final-newline": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+            "dev": true
+        },
         "strip-indent": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -13697,12 +16208,24 @@
             "dev": true
         },
         "style-loader": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.2.1.tgz",
-            "integrity": "sha512-ByHSTQvHLkWE9Ir5+lGbVOXhxX10fbprhLvdg96wedFZb4NDekDPxVKv5Fwmio+QcMlkkNfuK+5W1peQ5CUhZg==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.3.0.tgz",
+            "integrity": "sha512-V7TCORko8rs9rIqkSrlMfkqA63DfoGBBJmK1kKGCcSi+BWb4cqz0SRsnp4l6rU5iwOEd0/2ePv68SV22VXon4Q==",
             "requires": {
                 "loader-utils": "^2.0.0",
-                "schema-utils": "^2.6.6"
+                "schema-utils": "^2.7.0"
+            },
+            "dependencies": {
+                "loader-utils": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+                    "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+                    "requires": {
+                        "big.js": "^5.2.2",
+                        "emojis-list": "^3.0.0",
+                        "json5": "^2.1.2"
+                    }
+                }
             }
         },
         "style-to-object": {
@@ -13733,9 +16256,9 @@
             }
         },
         "styled-icons": {
-            "version": "10.21.0",
-            "resolved": "https://registry.npmjs.org/styled-icons/-/styled-icons-10.21.0.tgz",
-            "integrity": "sha512-QHK9Qo4BEYUzC+zIH5ZB6v83FGBegj3jF4XqXB7v+j1ptlmkNOMqt3ULWDnrvDbzzgkSDaPhPl+yZy/8x8JGtw==",
+            "version": "10.22.0",
+            "resolved": "https://registry.npmjs.org/styled-icons/-/styled-icons-10.22.0.tgz",
+            "integrity": "sha512-lBVPj1QT70xITygxHJAI54j2z168cayvqB5cOAaRR5HEbQZ5P3nFuXXPfytf/ZBsJzV6DXT5c2L/+ONeHeGRSQ==",
             "dev": true,
             "requires": {
                 "@babel/runtime": "^7.10.5",
@@ -13749,9 +16272,9 @@
                 "@styled-icons/evaicons-outline": "^10.18.0",
                 "@styled-icons/evaicons-solid": "^10.18.0",
                 "@styled-icons/evil": "^10.18.0",
-                "@styled-icons/fa-brands": "^10.18.0",
-                "@styled-icons/fa-regular": "^10.18.0",
-                "@styled-icons/fa-solid": "^10.18.0",
+                "@styled-icons/fa-brands": "^10.22.0",
+                "@styled-icons/fa-regular": "^10.22.0",
+                "@styled-icons/fa-solid": "^10.22.0",
                 "@styled-icons/feather": "^10.18.0",
                 "@styled-icons/foundation": "^10.18.0",
                 "@styled-icons/heroicons-outline": "^10.19.0",
@@ -13769,7 +16292,7 @@
                 "@styled-icons/open-iconic": "^10.18.0",
                 "@styled-icons/remix-fill": "^10.18.0",
                 "@styled-icons/remix-line": "^10.18.0",
-                "@styled-icons/simple-icons": "^10.21.0",
+                "@styled-icons/simple-icons": "^10.22.0",
                 "@styled-icons/styled-icon": "^10.6.0",
                 "@styled-icons/typicons": "^10.18.0",
                 "@styled-icons/zondicons": "^10.18.0"
@@ -13781,6 +16304,33 @@
             "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
             "requires": {
                 "has-flag": "^3.0.0"
+            }
+        },
+        "supports-hyperlinks": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz",
+            "integrity": "sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==",
+            "dev": true,
+            "requires": {
+                "has-flag": "^4.0.0",
+                "supports-color": "^7.0.0"
+            },
+            "dependencies": {
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
             }
         },
         "svg-parser": {
@@ -13820,9 +16370,9 @@
                     }
                 },
                 "css-what": {
-                    "version": "3.4.1",
-                    "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.1.tgz",
-                    "integrity": "sha512-wHOppVDKl4vTAOWzJt5Ek37Sgd9qq1Bmj/T1OjvicWbU5W7ru7Pqbn0Jdqii3Drx/h+dixHKXNhZYx7blthL7g=="
+                    "version": "3.4.2",
+                    "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
+                    "integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ=="
                 },
                 "domutils": {
                     "version": "1.7.0",
@@ -13840,6 +16390,12 @@
             "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
             "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
         },
+        "symbol-tree": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "dev": true
+        },
         "symbol.prototype.description": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/symbol.prototype.description/-/symbol.prototype.description-1.0.2.tgz",
@@ -13847,6 +16403,26 @@
             "requires": {
                 "es-abstract": "^1.17.0-next.1",
                 "has-symbols": "^1.0.1"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                }
             }
         },
         "table": {
@@ -13940,6 +16516,16 @@
             "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.0.tgz",
             "integrity": "sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw=="
         },
+        "terminal-link": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
+            "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
+            "dev": true,
+            "requires": {
+                "ansi-escapes": "^4.2.1",
+                "supports-hyperlinks": "^2.0.0"
+            }
+        },
         "terser": {
             "version": "4.8.0",
             "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
@@ -14031,6 +16617,12 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+        },
+        "throat": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+            "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
+            "dev": true
         },
         "throttle-debounce": {
             "version": "2.3.0",
@@ -14129,11 +16721,12 @@
             }
         },
         "to-regex-range": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+            "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
             "requires": {
-                "is-number": "^7.0.0"
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
             }
         },
         "toggle-selection": {
@@ -14145,6 +16738,26 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
             "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+        },
+        "tough-cookie": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+            "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+            "dev": true,
+            "requires": {
+                "ip-regex": "^2.1.0",
+                "psl": "^1.1.28",
+                "punycode": "^2.1.1"
+            }
+        },
+        "tr46": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
+            "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
+            "dev": true,
+            "requires": {
+                "punycode": "^2.1.1"
+            }
         },
         "trim": {
             "version": "0.0.1",
@@ -14173,6 +16786,46 @@
             "version": "2.0.12",
             "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-2.0.12.tgz",
             "integrity": "sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w=="
+        },
+        "ts-jest": {
+            "version": "26.4.2",
+            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.4.2.tgz",
+            "integrity": "sha512-0+MynTTzzbuy5rGjzsCKjxHJk5gY906c/FSaqQ3081+G7dp2Yygfa9hVlbrtNNcztffh1mC6Rs9jb/yHpcjsoQ==",
+            "dev": true,
+            "requires": {
+                "@jest/create-cache-key-function": "^26.5.0",
+                "@types/jest": "26.x",
+                "bs-logger": "0.x",
+                "buffer-from": "1.x",
+                "fast-json-stable-stringify": "2.x",
+                "jest-util": "^26.1.0",
+                "json5": "2.x",
+                "lodash.memoize": "4.x",
+                "make-error": "1.x",
+                "mkdirp": "1.x",
+                "semver": "7.x",
+                "yargs-parser": "20.x"
+            },
+            "dependencies": {
+                "mkdirp": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+                    "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "7.3.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+                    "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+                    "dev": true
+                },
+                "yargs-parser": {
+                    "version": "20.2.3",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.3.tgz",
+                    "integrity": "sha512-emOFRT9WVHw03QSvN5qor9QQT9+sw5vwxfYweivSMHTcAXPefwVae2FjO7JJjj8hCE4CzPOPeFM83VwT29HCww==",
+                    "dev": true
+                }
+            }
         },
         "ts-pnp": {
             "version": "1.2.0",
@@ -14203,9 +16856,9 @@
             }
         },
         "tslib": {
-            "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-            "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "tsutils": {
             "version": "3.17.1",
@@ -14220,6 +16873,21 @@
             "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
             "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
         },
+        "tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "tweetnacl": {
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+            "dev": true
+        },
         "type": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
@@ -14233,6 +16901,12 @@
             "requires": {
                 "prelude-ls": "~1.1.2"
             }
+        },
+        "type-detect": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+            "dev": true
         },
         "type-fest": {
             "version": "0.8.1",
@@ -14429,9 +17103,9 @@
             }
         },
         "unist-util-visit-parents": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.0.tgz",
-            "integrity": "sha512-0g4wbluTF93npyPrp/ymd3tCDTMnP0yo2akFD2FIBAYXq/Sga3lwaU1D8OYKbtpioaI6CkDcQ6fsMnmtzt7htw==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
+            "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
             "dev": true,
             "requires": {
                 "@types/unist": "^2.0.0",
@@ -14530,13 +17204,35 @@
             }
         },
         "url-loader": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-4.1.0.tgz",
-            "integrity": "sha512-IzgAAIC8wRrg6NYkFIJY09vtktQcsvU8V6HhtQj9PTefbYImzLB1hufqo4m+RyM5N3mLx5BqJKccgxJS+W3kqw==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-4.1.1.tgz",
+            "integrity": "sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==",
             "requires": {
                 "loader-utils": "^2.0.0",
-                "mime-types": "^2.1.26",
-                "schema-utils": "^2.6.5"
+                "mime-types": "^2.1.27",
+                "schema-utils": "^3.0.0"
+            },
+            "dependencies": {
+                "loader-utils": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+                    "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+                    "requires": {
+                        "big.js": "^5.2.2",
+                        "emojis-list": "^3.0.0",
+                        "json5": "^2.1.2"
+                    }
+                },
+                "schema-utils": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+                    "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
+                    "requires": {
+                        "@types/json-schema": "^7.0.6",
+                        "ajv": "^6.12.5",
+                        "ajv-keywords": "^3.5.2"
+                    }
+                }
             }
         },
         "use": {
@@ -14620,6 +17316,25 @@
             "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
             "dev": true
         },
+        "v8-to-istanbul": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-6.0.1.tgz",
+            "integrity": "sha512-PzM1WlqquhBvsV+Gco6WSFeg1AGdD53ccMRkFeyHRE/KRZaVacPOmQYP3EeVgDBtKD2BJ8kgynBQ5OtKiHCH+w==",
+            "dev": true,
+            "requires": {
+                "@types/istanbul-lib-coverage": "^2.0.1",
+                "convert-source-map": "^1.6.0",
+                "source-map": "^0.7.3"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.7.3",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+                    "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+                    "dev": true
+                }
+            }
+        },
         "validate-npm-package-license": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -14634,6 +17349,17 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
             "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+        },
+        "verror": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "^1.2.0"
+            }
         },
         "vfile": {
             "version": "4.2.0",
@@ -14676,6 +17402,24 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
             "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
+        },
+        "w3c-hr-time": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+            "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+            "dev": true,
+            "requires": {
+                "browser-process-hrtime": "^1.0.0"
+            }
+        },
+        "w3c-xmlserializer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+            "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
+            "dev": true,
+            "requires": {
+                "xml-name-validator": "^3.0.0"
+            }
         },
         "walker": {
             "version": "1.0.7",
@@ -14741,35 +17485,6 @@
                     "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
                     "optional": true
                 },
-                "braces": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-                    "optional": true,
-                    "requires": {
-                        "arr-flatten": "^1.1.0",
-                        "array-unique": "^0.3.2",
-                        "extend-shallow": "^2.0.1",
-                        "fill-range": "^4.0.0",
-                        "isobject": "^3.0.1",
-                        "repeat-element": "^1.1.2",
-                        "snapdragon": "^0.8.1",
-                        "snapdragon-node": "^2.0.1",
-                        "split-string": "^3.0.2",
-                        "to-regex": "^3.0.1"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "optional": true,
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
                 "chokidar": {
                     "version": "2.1.8",
                     "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
@@ -14790,38 +17505,11 @@
                         "upath": "^1.1.1"
                     }
                 },
-                "fill-range": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-                    "optional": true,
-                    "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1",
-                        "to-regex-range": "^2.1.0"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "optional": true,
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
                 "fsevents": {
                     "version": "1.2.13",
                     "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
                     "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-                    "optional": true,
-                    "requires": {
-                        "bindings": "^1.5.0",
-                        "nan": "^2.12.1"
-                    }
+                    "optional": true
                 },
                 "glob-parent": {
                     "version": "3.1.0",
@@ -14868,32 +17556,6 @@
                         "is-extglob": "^2.1.1"
                     }
                 },
-                "is-number": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                    "optional": true,
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "optional": true,
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
-                    }
-                },
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "optional": true
-                },
                 "micromatch": {
                     "version": "3.1.10",
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -14925,16 +17587,6 @@
                         "micromatch": "^3.1.10",
                         "readable-stream": "^2.0.2"
                     }
-                },
-                "to-regex-range": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-                    "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-                    "optional": true,
-                    "requires": {
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1"
-                    }
                 }
             }
         },
@@ -14942,6 +17594,12 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
             "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==",
+            "dev": true
+        },
+        "webidl-conversions": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+            "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
             "dev": true
         },
         "webpack": {
@@ -14974,38 +17632,6 @@
                 "webpack-sources": "^1.4.1"
             },
             "dependencies": {
-                "acorn": {
-                    "version": "6.4.1",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-                    "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
-                },
-                "braces": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-                    "requires": {
-                        "arr-flatten": "^1.1.0",
-                        "array-unique": "^0.3.2",
-                        "extend-shallow": "^2.0.1",
-                        "fill-range": "^4.0.0",
-                        "isobject": "^3.0.1",
-                        "repeat-element": "^1.1.2",
-                        "snapdragon": "^0.8.1",
-                        "snapdragon-node": "^2.0.1",
-                        "split-string": "^3.0.2",
-                        "to-regex": "^3.0.1"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
                 "cacache": {
                     "version": "12.0.4",
                     "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
@@ -15033,72 +17659,10 @@
                     "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
                     "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
                 },
-                "fill-range": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-                    "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1",
-                        "to-regex-range": "^2.1.0"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "is-number": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
-                    }
-                },
                 "is-wsl": {
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
                     "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
-                },
-                "isobject": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-                },
-                "json5": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-                    "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-                    "requires": {
-                        "minimist": "^1.2.0"
-                    }
-                },
-                "loader-utils": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-                    "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-                    "requires": {
-                        "big.js": "^5.2.2",
-                        "emojis-list": "^3.0.0",
-                        "json5": "^1.0.1"
-                    }
                 },
                 "lru-cache": {
                     "version": "5.1.1",
@@ -15165,15 +17729,6 @@
                         "terser": "^4.1.2",
                         "webpack-sources": "^1.4.0",
                         "worker-farm": "^1.7.0"
-                    }
-                },
-                "to-regex-range": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-                    "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-                    "requires": {
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1"
                     }
                 },
                 "yallist": {
@@ -15256,13 +17811,45 @@
                 }
             }
         },
+        "whatwg-encoding": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+            "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+            "dev": true,
+            "requires": {
+                "iconv-lite": "0.4.24"
+            }
+        },
+        "whatwg-mimetype": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+            "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+            "dev": true
+        },
+        "whatwg-url": {
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.4.0.tgz",
+            "integrity": "sha512-vwTUFf6V4zhcPkWp/4CQPr1TW9Ml6SF4lVyaIMBdJw5i6qUUJ1QWM4Z6YYVkfka0OUIzVo/0aNtGVGk256IKWw==",
+            "dev": true,
+            "requires": {
+                "lodash.sortby": "^4.7.0",
+                "tr46": "^2.0.2",
+                "webidl-conversions": "^6.1.0"
+            }
+        },
         "which": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "requires": {
                 "isexe": "^2.0.0"
             }
+        },
+        "which-module": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+            "dev": true
         },
         "which-pm-runs": {
             "version": "1.0.0",
@@ -15349,6 +17936,81 @@
                 "microevent.ts": "~0.1.1"
             }
         },
+        "wrap-ansi": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+            "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "emoji-regex": {
+                    "version": "8.0.0",
+                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+                    "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+                    "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.0"
+                    }
+                }
+            }
+        },
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -15375,6 +18037,24 @@
                 "typedarray-to-buffer": "^3.1.5"
             }
         },
+        "ws": {
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+            "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
+            "dev": true
+        },
+        "xml-name-validator": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+            "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+            "dev": true
+        },
+        "xmlchars": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+            "dev": true
+        },
         "xtend": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -15394,6 +18074,75 @@
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
             "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
+        },
+        "yargs": {
+            "version": "15.4.1",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+            "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+            "dev": true,
+            "requires": {
+                "cliui": "^6.0.0",
+                "decamelize": "^1.2.0",
+                "find-up": "^4.1.0",
+                "get-caller-file": "^2.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^2.0.0",
+                "set-blocking": "^2.0.0",
+                "string-width": "^4.2.0",
+                "which-module": "^2.0.0",
+                "y18n": "^4.0.0",
+                "yargs-parser": "^18.1.2"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "emoji-regex": {
+                    "version": "8.0.0",
+                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+                    "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+                    "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.0"
+                    }
+                }
+            }
+        },
+        "yargs-parser": {
+            "version": "18.1.3",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+            "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+            "dev": true,
+            "requires": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+            }
         },
         "zwitch": {
             "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
         "@storybook/addon-viewport": "^6.0.26",
         "@storybook/addons": "^6.0.26",
         "@storybook/react": "^6.0.26",
+        "@types/jest": "^26.0.15",
         "awesome-typescript-loader": "^5.2.1",
         "babel-loader": "^8.1.0",
         "babel-plugin-module-resolver": "^4.0.0",
@@ -62,12 +63,14 @@
         "eslint-plugin-jsx-a11y": "^6.3.1",
         "eslint-plugin-react": "^7.20.6",
         "husky": "^4.3.0",
+        "jest": "^26.6.1",
         "prettier": "^2.1.2",
         "react": "^16.13.1",
         "react-docgen-typescript-loader": "^3.7.2",
         "react-dom": "^16.13.1",
         "styled-components": "^5.2.0",
         "styled-icons": "^10.21.0",
+        "ts-jest": "^26.4.2",
         "typescript": "^4.0.2"
     },
     "aliases": {

--- a/src/Containers/LeftSideBar/CollapsibleHeader.tsx
+++ b/src/Containers/LeftSideBar/CollapsibleHeader.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import styled from 'styled-components';
 import { AngleDown } from '@styled-icons/fa-solid/AngleDown';
 import { StyledIcon } from '@styled-icons/styled-icon';
-import { 
+import {
     Draggable,
     DraggableProvided,
-    DraggableStateSnapshot
+    DraggableStateSnapshot,
 } from 'react-beautiful-dnd';
 import { ILeftSideBarInterface } from './ReceiptElements';
 import { getCategoryElements } from './ElementFunctions';
@@ -14,28 +14,31 @@ import { Heading } from '../../Text/Heading';
 import { MainInterface, ResponsiveInterface } from '../../Utils/BaseStyles';
 import { Mixins } from '../../Utils';
 
-export interface CollapsibleHeaderProps extends MainInterface, ResponsiveInterface, React.HTMLAttributes<HTMLDivElement> {
-    padding?: string,
-    headerSpacingStyle?: string,
-    icon?: StyledIcon,
-    category: string,
-    position: number,
-    isCollapsedArr: boolean[],
-    setIsCollapsedArr: React.Dispatch<React.SetStateAction<boolean []>>,
-    ReceiptElements: ILeftSideBarInterface
-};
+export interface CollapsibleHeaderProps
+    extends MainInterface,
+        ResponsiveInterface,
+        React.HTMLAttributes<HTMLDivElement> {
+    padding?: string;
+    headerSpacingStyle?: string;
+    icon?: StyledIcon;
+    category: string;
+    position: number;
+    isCollapsedArr: boolean[];
+    setIsCollapsedArr: React.Dispatch<React.SetStateAction<boolean[]>>;
+    ReceiptElements: ILeftSideBarInterface;
+}
 
 interface WrapperProps {
     padding?: string;
-};
+}
 
 interface RowProps {
     display?: string;
-};
+}
 
 interface IconProps {
     isCollapsed?: boolean;
-};
+}
 
 export const CollapsibleHeader: React.FC<CollapsibleHeaderProps> = ({
     padding = '10px 20px',
@@ -55,44 +58,50 @@ export const CollapsibleHeader: React.FC<CollapsibleHeaderProps> = ({
             <Row display={headerSpacingStyle}>
                 <Container>
                     <Icon as={icon} />
-                    <Heading bold type='h2' size='1.2rem' padding='0 0 0 5px'> 
-                        { category }
+                    <Heading bold type="h2" size="1.2rem" padding="0 0 0 5px">
+                        {category}
                     </Heading>
                 </Container>
                 <Icon
                     as={AngleDown}
                     isCollapsed={isCollapsedArr[position]}
                     onClick={(): void => {
-                        setIsCollapsedArr(isCollapsedArr.map((isCollapsed, idx) => {
-                            if(idx === position) return !isCollapsed;
-                            return isCollapsed;
-                        }));
+                        setIsCollapsedArr(
+                            isCollapsedArr.map((isCollapsed, idx) => {
+                                if (idx === position) return !isCollapsed;
+                                return isCollapsed;
+                            }),
+                        );
                     }}
                 />
             </Row>
-            {!!isCollapsedArr[position] && Object.values(categoryWithElements).map((element, index) => (
-                <Draggable
-                    key={element.key}
-                    draggableId={element.key}
-                    index={index}
-                >
-                    {(providedDraggable: DraggableProvided, snapshotDraggable: DraggableStateSnapshot) => (
-                        <>
-                            <DraggableElement
-                                key={element.key}
-                                providedDraggable={providedDraggable}
-                                isDragging={snapshotDraggable.isDragging}
-                                isRecommended={element.isRecommended}
-                                isRequired={element.isRequired}
-                            >
-                                { element.field }
-                            </DraggableElement>
-                        </>
-                    )}
-                </Draggable>
-            ))}
+            {!!isCollapsedArr[position] &&
+                Object.values(categoryWithElements).map((element, index) => (
+                    <Draggable
+                        key={element.key}
+                        draggableId={element.key}
+                        index={index}
+                    >
+                        {(
+                            providedDraggable: DraggableProvided,
+                            snapshotDraggable: DraggableStateSnapshot,
+                        ) => (
+                            <>
+                                <DraggableElement
+                                    key={element.key}
+                                    providedDraggable={providedDraggable}
+                                    isDragging={snapshotDraggable.isDragging}
+                                    isRecommended={element.isRecommended}
+                                    isRequired={element.isRequired}
+                                >
+                                    {element.field}
+                                </DraggableElement>
+                            </>
+                        )}
+                    </Draggable>
+                ))}
         </Wrapper>
-    )
+    );
 };
 
 const Wrapper = styled.div<WrapperProps>`
@@ -109,7 +118,8 @@ const Container = styled.div`
 `;
 const Icon = styled.svg<IconProps>`
     ${Mixins.transition(['transform'])}
-    transform: rotate(${({ isCollapsed }): string => (isCollapsed ? '180deg' : '0')});
+    transform: rotate(${({ isCollapsed }): string =>
+        isCollapsed ? '180deg' : '0'});
     height: 25px;
     margin: 5px 12px;
 `;

--- a/src/Containers/LeftSideBar/DraggableElement.tsx
+++ b/src/Containers/LeftSideBar/DraggableElement.tsx
@@ -5,23 +5,26 @@ import { DragIndicator } from '@styled-icons/material/DragIndicator';
 import { MainInterface, ResponsiveInterface } from '../../Utils/BaseStyles';
 import { styledCondition } from '../../Utils/Mixins';
 
-export interface DraggableElementProps extends MainInterface, ResponsiveInterface, React.HTMLAttributes<HTMLDivElement> {
-    providedDraggable: DraggableProvided,
-    isDragging?: boolean,
-    isRecommended: boolean,
-    isRequired: boolean
-};
+export interface DraggableElementProps
+    extends MainInterface,
+        ResponsiveInterface,
+        React.HTMLAttributes<HTMLDivElement> {
+    providedDraggable: DraggableProvided;
+    isDragging?: boolean;
+    isRecommended: boolean;
+    isRequired: boolean;
+}
 
 interface WrapperProps {
-    isDragging: boolean,
-    isRecommended: boolean,
-    isRequired: boolean
-};
+    isDragging: boolean;
+    isRecommended: boolean;
+    isRequired: boolean;
+}
 
 interface IconProps {
-    isRecommended: boolean,
-    isRequired: boolean
-};
+    isRecommended: boolean;
+    isRequired: boolean;
+}
 
 const BACKGROUND_GRAY = '#b7b7b7';
 const COLOR_IS_REQUIRED = '#de001f';
@@ -49,12 +52,12 @@ export const DraggableElement: React.FC<DraggableElementProps> = ({
             isRequired={isRequired}
             {...props}
         >
-            <Icon 
+            <Icon
                 as={DragIndicator}
                 isRecommended={isRecommended}
-                isRequired={isRequired} 
+                isRequired={isRequired}
             />
-            { children }
+            {children}
         </Wrapper>
     );
 };
@@ -71,18 +74,21 @@ const Wrapper = styled.div<WrapperProps>`
     border: solid 0.5px ${BACKGROUND_GRAY};
     box-shadow: 0 3px 2px 0 rgba(0, 0, 0, 0.15);
     ${({ isDragging, isRequired, isRecommended }): string => `
-        border-left: 5px solid ${isDragging && styledCondition(
-        isRequired,
-        COLOR_IS_REQUIRED,
-        isRecommended,
-        COLOR_IS_RECOMMENDED,
-        COLOR_DEFAULT
-    )};
+        border-left: 5px solid ${
+            isDragging &&
+            styledCondition(
+                isRequired,
+                COLOR_IS_REQUIRED,
+                isRecommended,
+                COLOR_IS_RECOMMENDED,
+                COLOR_DEFAULT,
+            )
+        };
         background-color: ${styledCondition(
-        isDragging,
-        BACKGROUND_GRAY,
-        COLOR_WHITE
-    )};
+            isDragging,
+            BACKGROUND_GRAY,
+            COLOR_WHITE,
+        )};
     `}
 
     :hover {
@@ -94,11 +100,11 @@ const Icon = styled.svg<IconProps>`
     flex-shrink: 0;
     ${({ isRequired, isRecommended }): string => `
         color: ${styledCondition(
-        isRequired,
-        COLOR_IS_REQUIRED,
-        isRecommended,
-        COLOR_IS_RECOMMENDED,
-        COLOR_DEFAULT
-    )};
+            isRequired,
+            COLOR_IS_REQUIRED,
+            isRecommended,
+            COLOR_IS_RECOMMENDED,
+            COLOR_DEFAULT,
+        )};
     `}
 `;

--- a/src/Containers/LeftSideBar/LeftSideBar.tsx
+++ b/src/Containers/LeftSideBar/LeftSideBar.tsx
@@ -1,13 +1,17 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { StyledIcon } from 'styled-icons/types';
-import { 
-    DragDropContext, 
+import {
+    DragDropContext,
     Droppable,
     DroppableProvided,
-    DroppableStateSnapshot
+    DroppableStateSnapshot,
 } from 'react-beautiful-dnd';
-import { IDraggableComponent, IElementWithCategory, ILeftSideBarInterface } from './ReceiptElements';
+import {
+    IDraggableComponent,
+    IElementWithCategory,
+    ILeftSideBarInterface,
+} from './ReceiptElements';
 import { CollapsibleHeader } from './CollapsibleHeader';
 import { List, ListToggle } from '../List';
 import { SearchBar } from '../../Inputs/SearchBar';
@@ -15,19 +19,22 @@ import { MainInterface, ResponsiveInterface } from '../../Utils/BaseStyles';
 
 const loading = false;
 
-export interface LeftSideBarProps extends MainInterface, ResponsiveInterface, React.HTMLAttributes<HTMLDivElement> {
-    ReceiptElements: ILeftSideBarInterface,
-    ElementWithCategory: IElementWithCategory [],
-    onDrag: () => void,
-    iconsList: StyledIcon[],
-    backgroundColor?: string,
-    hasIcon?: boolean,
-    dropDisabled?: boolean
-};
+export interface LeftSideBarProps
+    extends MainInterface,
+        ResponsiveInterface,
+        React.HTMLAttributes<HTMLDivElement> {
+    ReceiptElements: ILeftSideBarInterface;
+    ElementWithCategory: IElementWithCategory[];
+    onDrag: () => void;
+    iconsList: StyledIcon[];
+    backgroundColor?: string;
+    hasIcon?: boolean;
+    dropDisabled?: boolean;
+}
 
 interface WrapperProps {
-    isDragging: boolean
-};
+    isDragging: boolean;
+}
 
 export const LeftSideBar: React.FC<LeftSideBarProps> = ({
     ReceiptElements,
@@ -41,104 +48,123 @@ export const LeftSideBar: React.FC<LeftSideBarProps> = ({
 }): React.ReactElement => {
     const [isOpen, setIsOpen] = useState(true);
     const [searchValue, setSearchValue] = useState('');
-    const [isCollapsedArr, setIsCollapsedArr] = useState(Array(Object.values(ReceiptElements).length).fill(false))
+    const [isCollapsedArr, setIsCollapsedArr] = useState(
+        Array(Object.values(ReceiptElements).length).fill(false),
+    );
 
     useEffect((): void => {
         ElementWithCategory.forEach((el, index) => {
-            if(el.field.includes(searchValue)) {
-                setIsCollapsedArr(isCollapsedArr.map((isCollapsed, idx) => {
-                    if(idx === index) return true;
-                    return false;
-                }));
+            if (el.field.includes(searchValue)) {
+                setIsCollapsedArr(
+                    isCollapsedArr.map((isCollapsed, idx) => {
+                        if (idx === index) return true;
+                        return false;
+                    }),
+                );
             }
-        })
+        });
     }, [searchValue]);
-      
-    const draggableComponentsObj: IDraggableComponent = Object.values(ReceiptElements).map((ReceiptElement)  => {
-        return ReceiptElement.draggableComponents;
-    }).reduce((prev, current) => {
-        return {...prev, ...current};
-    });
+
+    const draggableComponentsObj: IDraggableComponent = Object.values(
+        ReceiptElements,
+    )
+        .map((ReceiptElement) => {
+            return ReceiptElement.draggableComponents;
+        })
+        .reduce((prev, current) => {
+            return { ...prev, ...current };
+        });
 
     return (
         <div {...props}>
-            <List 
-                id='left-sidebar'
+            <List
+                id="left-sidebar"
                 loading={loading}
-                cssPosition='absolute'
-                margin='0'
-                left='0'
-                right='auto'
-                onCloseTranslateXAxis='-100%'
+                cssPosition="absolute"
+                margin="0"
+                left="0"
+                right="auto"
+                onCloseTranslateXAxis="-100%"
                 isOpen={isOpen}
                 setIsOpen={setIsOpen}
-                toggleComponent={(
+                toggleComponent={
                     <ListToggle
                         isOpen={isOpen}
                         setIsOpen={setIsOpen}
                         isLeftToggle
                     />
-                )}
+                }
                 backgroundColor={backgroundColor}
-                header={(
+                header={
                     <>
                         <StyledSearchBar
-                            placeholder='Search'
-                            backgroundColor='white'
-                            borderRadius='40px'
-                            onChange={(e: { value: string, name: string }): void => {
+                            placeholder="Search"
+                            backgroundColor="white"
+                            borderRadius="40px"
+                            onChange={(e: {
+                                value: string;
+                                name: string;
+                            }): void => {
                                 setSearchValue(e.name);
                             }}
                             hasIcon={hasIcon}
                             value={searchValue}
                         >
-                            {Object.values(draggableComponentsObj).map((draggable) => {
-                                return (
-                                    <option value={draggable.key}>
-                                        {draggable.field}
-                                    </option>
-                                );
-                            })}
+                            {Object.values(draggableComponentsObj).map(
+                                (draggable) => {
+                                    return (
+                                        <option value={draggable.key}>
+                                            {draggable.field}
+                                        </option>
+                                    );
+                                },
+                            )}
                         </StyledSearchBar>
                     </>
-                )}
+                }
             >
-                <DragDropContext
-                    onDragEnd={onDrag}
-                >
+                <DragDropContext onDragEnd={onDrag}>
                     <Droppable
-                        droppableId='LEFT-BAR'
+                        droppableId="LEFT-BAR"
                         isDropDisabled={dropDisabled}
                     >
-                        {(provided: DroppableProvided, snapshot: DroppableStateSnapshot) => (
+                        {(
+                            provided: DroppableProvided,
+                            snapshot: DroppableStateSnapshot,
+                        ) => (
                             <Wrapper
                                 ref={provided.innerRef}
                                 {...provided.droppableProps}
                                 isDragging={snapshot.isDraggingOver}
                             >
-                                {Object.values(ReceiptElements).map((ReceiptElement, index) => (
-                                    <CollapsibleHeader 
-                                        key={ReceiptElement.key}
-                                        icon={iconsList[index]}
-                                        category={ReceiptElement.editorCategory}
-                                        position={index}
-                                        isCollapsedArr={isCollapsedArr}
-                                        setIsCollapsedArr={setIsCollapsedArr}
-                                        ReceiptElements={ReceiptElements}
-                                    />
-                                ))}
-                                { provided.placeholder }
+                                {Object.values(ReceiptElements).map(
+                                    (ReceiptElement, index) => (
+                                        <CollapsibleHeader
+                                            key={ReceiptElement.key}
+                                            icon={iconsList[index]}
+                                            category={
+                                                ReceiptElement.editorCategory
+                                            }
+                                            position={index}
+                                            isCollapsedArr={isCollapsedArr}
+                                            setIsCollapsedArr={
+                                                setIsCollapsedArr
+                                            }
+                                            ReceiptElements={ReceiptElements}
+                                        />
+                                    ),
+                                )}
+                                {provided.placeholder}
                             </Wrapper>
                         )}
                     </Droppable>
                 </DragDropContext>
             </List>
-        </div>  
-    )
+        </div>
+    );
 };
 
-const Wrapper = styled.div<WrapperProps>`
-`;
+const Wrapper = styled.div<WrapperProps>``;
 const StyledSearchBar = styled(SearchBar)`
     ${({ theme }): string => `
         padding: ${theme.dimensions.padding.container};

--- a/src/Containers/List/List.tsx
+++ b/src/Containers/List/List.tsx
@@ -60,10 +60,10 @@ export const List: React.FC<ListProps> = ({
 
     return (
         <Wrapper isOpen={isOpen} {...props}>
-            <Container 
-                columnWidth={columnWidth} 
+            <Container
+                columnWidth={columnWidth}
                 id={id}
-                backgroundColor={backgroundColor} 
+                backgroundColor={backgroundColor}
             >
                 {header}
                 <Items>{loading ? <Loading /> : children}</Items>

--- a/src/Utils/deepCopy.ts
+++ b/src/Utils/deepCopy.ts
@@ -1,25 +1,20 @@
 /**
  * Performs a deep copy of variable
- * @param {*} obj - Literally anything
+ * @param {*} original - Literally anything
  * @returns {*} Deep copy version of param
  */
-export const deepCopy = (
-    obj: object | boolean | string | number,
-): object | boolean | string | number => {
-    if (Array.isArray(obj)) {
-        return obj.map((item: object | boolean | string | number):
-            | object
-            | boolean
-            | string
-            | number => deepCopy(item));
+export const deepCopy = <T>(original: T): T => {
+    if (original instanceof Date) {
+        return new Date(original) as any;
     }
-
-    if (typeof obj === 'object' && obj !== null) {
-        return Object.entries(obj).reduce((acc, [key, value]): object => {
+    if (Array.isArray(original)) {
+        return original.map((item: any) => deepCopy<any>(item)) as any;
+    }
+    if (typeof original === 'object') {
+        return Object.entries(original).reduce((acc, [key, value]: [string, any]) => {
             acc[key] = deepCopy(value);
             return acc;
-        }, {});
+        }, {}) as T;
     }
-
-    return obj;
+    return original;
 };

--- a/stories/Containers/LeftSideBar.stories.tsx
+++ b/stories/Containers/LeftSideBar.stories.tsx
@@ -22,59 +22,59 @@ export default {
             ListNumbered,
             Dollar,
             Qrcode,
-            Settings
-        ],  
+            Settings,
+        ],
         backgroundColor: '#f2f2f2',
-        hasIcon: false,     
+        hasIcon: false,
         dropDisabled: false,
         ReceiptElements: {
             textElements: {
                 key: 'Text',
                 editorCategory: 'Text',
                 draggableComponents: {
-                    NAME_OF_BUSINESS: {   
+                    NAME_OF_BUSINESS: {
                         key: '1',
                         field: 'Name of business',
                         isRequired: true,
-                        isRecommended: false
+                        isRecommended: false,
                     },
                     ADDRESS_OF_BUSINESS: {
                         key: '2',
                         field: 'Address of business',
                         isRequired: true,
-                        isRecommended: false
+                        isRecommended: false,
                     },
                     CONTACT_INFORMATION: {
                         key: '3',
                         field: 'Business contact information',
                         isRequired: true,
-                        isRecommended: false
+                        isRecommended: false,
                     },
                     NAME_OF_SALES_ASSOCIATE: {
                         key: '4',
                         field: 'Name of sales associate',
                         isRequired: true,
-                        isRecommended: false
+                        isRecommended: false,
                     },
                     NAME_OF_PRODUCT: {
                         key: '5',
                         field: 'Name of product or service',
                         isRequired: true,
-                        isRecommended: false
+                        isRecommended: false,
                     },
                     ORDER_TYPE: {
                         key: '6',
                         field: 'Order type',
                         isRequired: false,
-                        isRecommended: true
+                        isRecommended: true,
                     },
                     PAYMENT_METHOD: {
                         key: '7',
                         field: 'Payment method',
                         isRequired: false,
-                        isRecommended: true
-                    }
-                }
+                        isRecommended: true,
+                    },
+                },
             },
             imageElements: {
                 key: 'Image',
@@ -84,15 +84,15 @@ export default {
                         key: '8',
                         field: 'Business logo',
                         isRequired: false,
-                        isRecommended: true
+                        isRecommended: true,
                     },
                     ADDITIONAL_BRANDING: {
                         key: '9',
                         field: 'Additional branding',
                         isRequired: false,
-                        isRecommended: true
-                    }
-                }
+                        isRecommended: true,
+                    },
+                },
             },
             layoutElements: {
                 key: 'Layout',
@@ -102,21 +102,21 @@ export default {
                         key: '10',
                         field: 'Menu table',
                         isRequired: true,
-                        isRecommended: false
+                        isRecommended: false,
                     },
                     WHITE_SPACE: {
                         key: '11',
                         field: 'White space',
                         isRequired: false,
-                        isRecommended: true
+                        isRecommended: true,
                     },
                     DIVIDER: {
                         key: '12',
                         field: 'Divider',
                         isRequired: false,
-                        isRecommended: true
-                    }
-                }
+                        isRecommended: true,
+                    },
+                },
             },
             numberElements: {
                 key: 'Number',
@@ -126,27 +126,27 @@ export default {
                         key: '13',
                         field: 'Station number',
                         isRequired: true,
-                        isRecommended: false
+                        isRecommended: false,
                     },
                     QUANTITY_PRODUCT: {
                         key: '14',
                         field: 'Quantity of product or service',
                         isRequired: true,
-                        isRecommended: false
+                        isRecommended: false,
                     },
                     NUMBER_OF_GUESTS: {
                         key: '15',
                         field: 'Number of guests',
                         isRequired: false,
-                        isRecommended: true
+                        isRecommended: true,
                     },
                     TRANSACTION_ORDER_NUMBER: {
                         key: '16',
                         field: 'Transaction order number',
                         isRequired: false,
-                        isRecommended: true
+                        isRecommended: true,
                     },
-                }
+                },
             },
             priceElements: {
                 key: 'Price',
@@ -156,45 +156,45 @@ export default {
                         key: '17',
                         field: 'Sale price',
                         isRequired: true,
-                        isRecommended: false
+                        isRecommended: false,
                     },
                     TOTAL_TAX: {
                         key: '18',
                         field: 'Total amount of tax',
                         isRequired: true,
-                        isRecommended: false
+                        isRecommended: false,
                     },
                     RATE_OF_SALES_TAX: {
                         key: '19',
                         field: 'Rate of sales tax',
                         isRequired: true,
-                        isRecommended: false
+                        isRecommended: false,
                     },
                     TOTAL_SALE_PRICE: {
                         key: '20',
                         field: 'Total price of sale',
                         isRequired: false,
-                        isRecommended: true
+                        isRecommended: true,
                     },
                     TIP: {
                         key: '21',
                         field: 'Tips',
                         isRequired: false,
-                        isRecommended: true
+                        isRecommended: true,
                     },
                     TOLAL_PRICE_WITH_TAX: {
                         key: '22',
                         field: 'Total price of sale with tax',
                         isRequired: false,
-                        isRecommended: true
+                        isRecommended: true,
                     },
                     TOTAL_PRICE_WITH_TIPS: {
                         key: '23',
                         field: 'Total price with tip',
                         isRequired: false,
-                        isRecommended: true
-                    }
-                }
+                        isRecommended: true,
+                    },
+                },
             },
             codesElements: {
                 key: 'Codes',
@@ -204,15 +204,15 @@ export default {
                         key: '24',
                         field: 'UPC code',
                         isRequired: true,
-                        isRecommended: false
+                        isRecommended: false,
                     },
                     QR_CODE: {
                         key: '25',
                         field: 'QR code',
                         isRequired: false,
-                        isRecommended: true
-                    }
-                }
+                        isRecommended: true,
+                    },
+                },
             },
             settingsElements: {
                 key: 'Settings',
@@ -222,16 +222,16 @@ export default {
                         key: '26',
                         field: 'Date',
                         isRequired: true,
-                        isRecommended: false
+                        isRecommended: false,
                     },
                     TIME: {
                         key: '27',
                         field: 'Time',
                         isRequired: true,
-                        isRecommended: false
-                    }
-                }
-            }
+                        isRecommended: false,
+                    },
+                },
+            },
         },
         ElementWithCategory: [
             {
@@ -243,23 +243,16 @@ export default {
                     'Name of sales associate',
                     'Name of product or service',
                     'Order type',
-                    'Payment method'
-                ]
+                    'Payment method',
+                ],
             },
             {
                 editorCategory: 'Image',
-                field: [
-                    'Business logo',
-                    'Additional branding'
-                ]
+                field: ['Business logo', 'Additional branding'],
             },
             {
                 editorCategory: 'Layout',
-                field: [
-                    'Menu table',
-                    'White space',
-                    'Divider'
-                ]
+                field: ['Menu table', 'White space', 'Divider'],
             },
             {
                 editorCategory: 'Number',
@@ -268,7 +261,7 @@ export default {
                     'Quantity of product or service',
                     'Number of guests',
                     'Transaction order number',
-                ]
+                ],
             },
             {
                 editorCategory: 'Price',
@@ -279,25 +272,19 @@ export default {
                     'Total price of sale',
                     'Tips',
                     'Total price of sale with tax',
-                    'Total price with tip'
-                ]
+                    'Total price with tip',
+                ],
             },
             {
                 editorCategory: 'Codes',
-                field: [
-                    'UPC code',
-                    'QR code'
-                ]
+                field: ['UPC code', 'QR code'],
             },
             {
                 editorCategory: 'Settings',
-                field: [
-                    'Date',
-                    'Time'
-                ]
-            }
-        ]
-    }
+                field: ['Date', 'Time'],
+            },
+        ],
+    },
 } as Meta;
 
 export const Basic: Story<LeftSideBarProps> = (args) => (

--- a/stories/Inputs/ColorPicker.stories.tsx
+++ b/stories/Inputs/ColorPicker.stories.tsx
@@ -1,17 +1,17 @@
 import React, { useState } from 'react';
 import { ColorPicker, ColorPickerProps } from '../../src';
-import { createStoryTitle } from "../Constants";
+import { createStoryTitle } from '../Constants';
 import { Meta, Story } from '@storybook/react';
 
 export default {
-  title: createStoryTitle('Color picker'),
-  component: ColorPicker,
-  argTypes: { onChange: { action: 'Color changed' } },
-  args: {
-      value: '#ff0000',
-  },
+    title: createStoryTitle('Color picker'),
+    component: ColorPicker,
+    argTypes: { onChange: { action: 'Color changed' } },
+    args: {
+        value: '#ff0000',
+    },
 } as Meta;
 
 export const Basic: Story<ColorPickerProps> = (args) => (
-  <ColorPicker {...args}></ColorPicker>
-)
+    <ColorPicker {...args}></ColorPicker>
+);

--- a/stories/Inputs/ComboBox.stories.tsx
+++ b/stories/Inputs/ComboBox.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ComboBox, ComboBoxSelectorProps } from '../../src';
-import { createStoryTitle } from "../Constants";
+import { createStoryTitle } from '../Constants';
 import { Meta, Story } from '@storybook/react';
 
 export default {
@@ -25,4 +25,4 @@ export default {
 
 export const Basic: Story<ComboBoxSelectorProps> = (args) => (
     <ComboBox {...args}></ComboBox>
-)
+);

--- a/stories/Inputs/Image.stories.tsx
+++ b/stories/Inputs/Image.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Meta, Story } from '@storybook/react';
-import {createStoryTitle} from "../Constants";
+import { createStoryTitle } from '../Constants';
 import { Image, ImageProps } from '../../src';
 
 export default {
@@ -13,6 +13,4 @@ export default {
     },
 } as Meta;
 
-export const Basic: Story<ImageProps> = (args) => (
-    <Image {...args}></Image>
-)
+export const Basic: Story<ImageProps> = (args) => <Image {...args}></Image>;

--- a/stories/Inputs/Input.stories.tsx
+++ b/stories/Inputs/Input.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Input, InputProps } from '../../src';
-import { createStoryTitle } from "../Constants";
+import { createStoryTitle } from '../Constants';
 import { Meta, Story } from '@storybook/react';
 
 export default {
@@ -13,21 +13,22 @@ export default {
     },
 } as Meta;
 
-export const Basic: Story<InputProps> = (args) => (
-    <Input {...args}></Input>
-);
+export const Basic: Story<InputProps> = (args) => <Input {...args}></Input>;
 
 export const WithSuccess = Basic.bind({});
 WithSuccess.args = {
-    ...WithSuccess.args, success: true 
+    ...WithSuccess.args,
+    success: true,
 };
 
 export const WithError = Basic.bind({});
-    WithError.args = {
-    ...WithError.args, error: 'Error message!',
+WithError.args = {
+    ...WithError.args,
+    error: 'Error message!',
 };
 
 export const WithDisabled = Basic.bind({});
-    WithDisabled.args = {
-    ...WithDisabled.args, disabled: true,
+WithDisabled.args = {
+    ...WithDisabled.args,
+    disabled: true,
 };

--- a/stories/Inputs/Textarea.stories.tsx
+++ b/stories/Inputs/Textarea.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Textarea, TextareaProps } from '../../src';
-import { createStoryTitle } from "../Constants";
+import { createStoryTitle } from '../Constants';
 import { Meta, Story } from '@storybook/react';
 
 export default {
@@ -19,15 +19,18 @@ export const Basic: Story<TextareaProps> = (args) => (
 
 export const WithSuccess = Basic.bind({});
 WithSuccess.args = {
-    ...WithSuccess.args, success: true
+    ...WithSuccess.args,
+    success: true,
 };
 
 export const WithError = Basic.bind({});
 WithError.args = {
-    ...WithError.args, error: 'Oops! Error message!'
+    ...WithError.args,
+    error: 'Oops! Error message!',
 };
 
 export const Disabled = Basic.bind({});
 Disabled.args = {
-    ...Disabled.args, disabled: true
+    ...Disabled.args,
+    disabled: true,
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,6 +39,6 @@
             "@Utils": ["./Utils"]
         }
     },
-    "include": ["src/**/*"],
+    "include": ["src/**/*", "__tests__"],
     "exclude": ["node_modules", "scripts", "dist"]
 }


### PR DESCRIPTION
deepCopy's previous iteration caused issues in typescript files and did not allow for typed returns.

Now deepCopy returns the the correct typing.

babel.config.js is needed specifically for jest to work.
