### PR TITLE
CEM-1234 update navigationitem

### DIFF
--- a/src/Containers/Navigation/NavigationItem.tsx
+++ b/src/Containers/Navigation/NavigationItem.tsx
@@ -13,6 +13,7 @@ const hydratePath = (path: string, params: NavigationParams) =>
 interface _NavigationItemProps {
     icon?: StyledIcon;
     to?: string;
+    exact?: boolean;
     type?: any | string | number | symbol;
     theme: DefaultTheme;
 }
@@ -25,6 +26,7 @@ const _NavigationItem: React.FC<_NavigationItemProps> = ({
     children,
     icon,
     to = '',
+    exact = false,
     type,
     theme,
     ...props
@@ -36,6 +38,7 @@ const _NavigationItem: React.FC<_NavigationItemProps> = ({
             <NavLink
                 to={hydratePath(to, params)}
                 target={isExternal ? '_blank' : ''}
+                exact={exact}
             >
                 <Icon as={icon} />
                 <Paragraph

--- a/stories/Containers/Navigation.stories.tsx
+++ b/stories/Containers/Navigation.stories.tsx
@@ -4,6 +4,7 @@ import { AppleAlt } from '@styled-icons/fa-solid/AppleAlt';
 import { Archive } from '@styled-icons/fa-solid/Archive';
 import { BrowserRouter } from 'react-router-dom';
 import { Compass } from '@styled-icons/fa-solid/Compass';
+import { Home } from '@styled-icons/fa-solid/Home';
 import {
     Navigation,
     NavigationProps,
@@ -25,6 +26,7 @@ interface NavProps {
     to: string;
     label?: string;
     icon: React.ForwardRefExoticComponent<React.RefAttributes<SVGSVGElement>>;
+    exact?: boolean;
 }
 
 interface IPages {
@@ -45,8 +47,16 @@ const pages: IPages = {
     Item2: {
         component: null,
         navProps: {
-            to: '/:id/orders',
+            to: '/:id/whatever',
             icon: Archive,
+        },
+    },
+    Home: {
+        component: null,
+        navProps: {
+            to: '/:id',
+            icon: Home,
+            exact: true,
         },
     },
 };


### PR DESCRIPTION
<img width="292" alt="Screenshot 2020-11-17 at 10 30 23" src="https://user-images.githubusercontent.com/29568460/99372045-f2110b80-28bf-11eb-863a-2a439e2f8c25.png">
NavigationItem did not have exact property. This make that when a link other than home is selected, two links appears with active class, the one selected and home. With this fix then only one link would appear with active class, the one selected.
