### PR TITLE
CEM-1249 expand options when clicked on input

### DIFF
--- a/src/Inputs/ComboBox.tsx
+++ b/src/Inputs/ComboBox.tsx
@@ -144,6 +144,7 @@ const _Select: React.FC<ComboBoxSelectorProps> = ({
     const handleChange = (event: SyntheticEvent<HTMLInputElement>): void => {
         setinputValue(event.currentTarget.value);
         setExpanded(true);
+        event.stopPropagation();
     };
 
     return (


### PR DESCRIPTION
![combobox](https://user-images.githubusercontent.com/29568460/100019322-1f891800-2dde-11eb-998a-987d32c7bd41.gif)
Previous behavior did not expand options when clicking on the input field. Behavior still is not 100 percent satisfactory. 