### PR TITLE
CEM-1251 Masked Input Fix

### DIFF
--- a/src/Inputs/MaskedInput.tsx
+++ b/src/Inputs/MaskedInput.tsx
@@ -7,7 +7,6 @@ import {
 } from '../Fragments';
 
 const MINUS_SIGN = '-';
-const EMPTY_STRING = '';
 const MIN_LESS_THAN_ZERO = 0;
 const ERROR_MESSAGE_VALUE_CALCUALTION = 1;
 const VALIDATE_INPUT_FORMAT = /^-?[0-9]*$/gm;
@@ -19,46 +18,11 @@ export enum MaskedInputPreset {
 
 export interface MaskedInputProps extends LabelLayoutProps, InputFragmentProps {
     realValue: string;
-    onRealValueChange: (value: string) => void;
+    onRealValueChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
     mask: MaskedInputPreset | ((value: string) => string);
     min?: number;
     max?: number;
 }
-
-const DOLLAR_FORMAT_MASK = (s: string): string => {
-    const number = +s;
-    if (Number.isNaN(number)) {
-        return 'Invalid value.';
-    }
-    if (number < 0) {
-        return `-$${-number.toFixed(2)}`;
-    }
-    return `$${number.toFixed(2)}`;
-};
-
-const PERCENT_FORMAT_MASK = (s: string): string => {
-    const number = +s;
-    if (Number.isNaN(number)) {
-        return 'Invalid value.';
-    }
-    if (number < 0) {
-        return `-${-number.toFixed(0)}%`;
-    }
-    return `${number.toFixed(0)}%`;
-};
-
-const getMaskFunction_ = (
-    mask: MaskedInputPreset | ((value: string) => string),
-): ((value: string) => string) => {
-    switch (mask) {
-        case MaskedInputPreset.DOLLAR:
-            return DOLLAR_FORMAT_MASK;
-        case MaskedInputPreset.PERCENTAGE:
-            return PERCENT_FORMAT_MASK;
-        default:
-            return mask as (value: string) => string;
-    }
-};
 
 export const MaskedInput: React.FC<MaskedInputProps> = ({
     mask,
@@ -72,7 +36,45 @@ export const MaskedInput: React.FC<MaskedInputProps> = ({
     const [isFocused, setIsFocused] = useState(false);
     const [isError, setIsError] = useState<boolean | string>(false);
 
-    const inputValidator = (targetValue: string) => {
+    const DOLLAR_FORMAT_MASK = (s: string): string => {
+        const number = parseInt(s, 10);
+        if (Number.isNaN(number)) {
+            setIsError('Value cannot be empty');
+            return '';
+        }
+        if (number < 0) {
+            return `-$${-number.toFixed(2)}`;
+        }
+        return `$${number.toFixed(2)}`;
+    };
+
+    const PERCENT_FORMAT_MASK = (s: string): string => {
+        const number = parseInt(s, 10);
+        if (Number.isNaN(number)) {
+            setIsError('Value cannot be empty');
+            return '';
+        }
+        if (number < 0) {
+            return `-${-number.toFixed(0)}%`;
+        }
+        return `${number.toFixed(0)}%`;
+    };
+
+    const getMaskFunction_ = (
+        maskInputPreset: MaskedInputPreset | ((value: string) => string),
+    ): ((value: string) => string) => {
+        switch (maskInputPreset) {
+            case MaskedInputPreset.DOLLAR:
+                return DOLLAR_FORMAT_MASK;
+            case MaskedInputPreset.PERCENTAGE:
+                return PERCENT_FORMAT_MASK;
+            default:
+                return mask as (value: string) => string;
+        }
+    };
+
+    const inputValidator = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const targetValue = event.target.value;
         const targetValueInteger = parseFloat(targetValue);
         const greaterThanMin = targetValueInteger >= min;
         const lessThanMax = targetValueInteger <= max;
@@ -81,15 +83,16 @@ export const MaskedInput: React.FC<MaskedInputProps> = ({
         if (!targetValue.match(VALIDATE_INPUT_FORMAT)) {
             setIsError('Invalid Character');
         } else if (greaterThanMin && lessThanMax) {
-            onRealValueChange(targetValue);
+            onRealValueChange(event);
             setDisplayValue(targetValue);
         } else if (targetValue === MINUS_SIGN && min < MIN_LESS_THAN_ZERO) {
-            onRealValueChange(targetValue);
+            onRealValueChange(event);
             setDisplayValue(targetValue);
         } else if (Number.isNaN(targetValueInteger)) {
-            onRealValueChange(EMPTY_STRING);
+            onRealValueChange(event);
         } else {
             setDisplayValue(targetValue);
+            onRealValueChange(event);
             const errorMessage = !greaterThanMin
                 ? `greater than ${min - ERROR_MESSAGE_VALUE_CALCUALTION}`
                 : `less than ${max + ERROR_MESSAGE_VALUE_CALCUALTION}`;
@@ -119,7 +122,7 @@ export const MaskedInput: React.FC<MaskedInputProps> = ({
                 }}
                 onChange={(e): void => {
                     if (isFocused) {
-                        inputValidator(e.target.value);
+                        inputValidator(e);
                     }
                 }}
                 {...props}

--- a/src/Inputs/MaskedInput.tsx
+++ b/src/Inputs/MaskedInput.tsx
@@ -18,7 +18,7 @@ export enum MaskedInputPreset {
 
 export interface MaskedInputProps extends LabelLayoutProps, InputFragmentProps {
     realValue: string;
-    onRealValueChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+    onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
     mask: MaskedInputPreset | ((value: string) => string);
     min?: number;
     max?: number;
@@ -27,7 +27,7 @@ export interface MaskedInputProps extends LabelLayoutProps, InputFragmentProps {
 export const MaskedInput: React.FC<MaskedInputProps> = ({
     mask,
     realValue,
-    onRealValueChange,
+    onChange,
     min = 0,
     max = 100,
     ...props
@@ -83,16 +83,16 @@ export const MaskedInput: React.FC<MaskedInputProps> = ({
         if (!targetValue.match(VALIDATE_INPUT_FORMAT)) {
             setIsError('Invalid Character');
         } else if (greaterThanMin && lessThanMax) {
-            onRealValueChange(event);
+            onChange(event);
             setDisplayValue(targetValue);
         } else if (targetValue === MINUS_SIGN && min < MIN_LESS_THAN_ZERO) {
-            onRealValueChange(event);
+            onChange(event);
             setDisplayValue(targetValue);
         } else if (Number.isNaN(targetValueInteger)) {
-            onRealValueChange(event);
+            onChange(event);
         } else {
             setDisplayValue(targetValue);
-            onRealValueChange(event);
+            onChange(event);
             const errorMessage = !greaterThanMin
                 ? `greater than ${min - ERROR_MESSAGE_VALUE_CALCUALTION}`
                 : `less than ${max + ERROR_MESSAGE_VALUE_CALCUALTION}`;

--- a/src/Utils/BaseStyles/Main.ts
+++ b/src/Utils/BaseStyles/Main.ts
@@ -17,10 +17,10 @@ export const Main = ({
 
     // Inline Styles
     ${
-        typeof inlineStyle === 'function'
-            ? inlineStyle({ ...props, margin, padding })
-            : inlineStyle
-    };
+    typeof inlineStyle === 'function'
+        ? inlineStyle({ ...props, margin, padding })
+        : inlineStyle
+};
 `;
 
 export const MainProps: string[] = ['margin', 'padding', 'inlineStyle'];

--- a/src/Utils/FormatDate.ts
+++ b/src/Utils/FormatDate.ts
@@ -31,17 +31,17 @@ export class FormatDate {
 
         let res = this.date.getMonth().toString();
         switch (type) {
-            case 'MM':
-                res = res.padStart(2, '0');
-                break;
-            case 'MMM':
-                res = MONTHS[res].slice(0, 3);
-                break;
-            case 'MMMM':
-                res = MONTHS[res];
-                break;
-            default:
-                break;
+        case 'MM':
+            res = res.padStart(2, '0');
+            break;
+        case 'MMM':
+            res = MONTHS[res].slice(0, 3);
+            break;
+        case 'MMMM':
+            res = MONTHS[res];
+            break;
+        default:
+            break;
         }
         this._res += prepend + res + append;
         return this;
@@ -52,17 +52,17 @@ export class FormatDate {
 
         let res = this.date.getDay().toString();
         switch (type) {
-            case 'WW':
-                res = res.padStart(2, '0');
-                break;
-            case 'WWW':
-                res = WEEKDAYS[res].slice(0, 3);
-                break;
-            case 'WWWW':
-                res = WEEKDAYS[res];
-                break;
-            default:
-                break;
+        case 'WW':
+            res = res.padStart(2, '0');
+            break;
+        case 'WWW':
+            res = WEEKDAYS[res].slice(0, 3);
+            break;
+        case 'WWWW':
+            res = WEEKDAYS[res];
+            break;
+        default:
+            break;
         }
         this._res += prepend + res + append;
         return this;
@@ -82,17 +82,17 @@ export class FormatDate {
 
         let res = this.date.getHours().toString();
         switch (type) {
-            case 'hh':
-                res = res.padStart(2, '0');
-                break;
-            case 'hp':
-                res = (parseInt(res, 10) % 12).toString();
-                break;
-            case 'hhp':
-                res = (parseInt(res, 10) % 12).toString().padStart(2, '0');
-                break;
-            default:
-                break;
+        case 'hh':
+            res = res.padStart(2, '0');
+            break;
+        case 'hp':
+            res = (parseInt(res, 10) % 12).toString();
+            break;
+        case 'hhp':
+            res = (parseInt(res, 10) % 12).toString().padStart(2, '0');
+            break;
+        default:
+            break;
         }
         this._res += prepend + res + append;
         return this;

--- a/src/Utils/Mixins/flex.ts
+++ b/src/Utils/Mixins/flex.ts
@@ -23,15 +23,15 @@ export const flex = (
         return `
             display: flex;
             ${
-                FLEX_DIRECTIONS.includes(param1)
-                    ? `
+    FLEX_DIRECTIONS.includes(param1)
+        ? `
                 flex-direction: ${param1};
             `
-                    : `
+        : `
                 justify-content: ${param1};
                 align-items: ${param1};
             `
-            }
+}
         `;
     }
 
@@ -40,17 +40,17 @@ export const flex = (
         return `
             display: flex;
             ${
-                FLEX_DIRECTIONS.includes(param1)
-                    ? `
+    FLEX_DIRECTIONS.includes(param1)
+        ? `
                 flex-direction: ${param1};
                 justify-content: ${param2};
                 align-items: ${param2};
             `
-                    : `
+        : `
                 justify-content: ${param1};
                 align-items: ${param2};
             `
-            }
+}
         `;
     }
 

--- a/stories/Inputs/MaskedInput.stories.tsx
+++ b/stories/Inputs/MaskedInput.stories.tsx
@@ -38,7 +38,7 @@ export default {
 
 export const Basic: Story<MaskedInputProps> = (args) => {
     const [{ realValue }, updateArgs] = useArgs();
-    const onRealValueChange = (value: string) =>
-        updateArgs({ realValue: value });
+    const onRealValueChange = (event: React.ChangeEvent<HTMLInputElement>) =>
+        updateArgs({ realValue: event.target.value });
     return <MaskedInput onRealValueChange={onRealValueChange} {...args} />;
 };

--- a/stories/Inputs/MaskedInput.stories.tsx
+++ b/stories/Inputs/MaskedInput.stories.tsx
@@ -38,7 +38,7 @@ export default {
 
 export const Basic: Story<MaskedInputProps> = (args) => {
     const [{ realValue }, updateArgs] = useArgs();
-    const onRealValueChange = (event: React.ChangeEvent<HTMLInputElement>) =>
+    const onChange = (event: React.ChangeEvent<HTMLInputElement>) =>
         updateArgs({ realValue: event.target.value });
-    return <MaskedInput onRealValueChange={onRealValueChange} {...args} />;
+    return <MaskedInput onChange={onChange} {...args} />;
 };


### PR DESCRIPTION
Reason for this fix, string coersion to number is bad. 

Also, updating onRealValueChange, more consistent to get an event from MaskedInput when dealing with other input elements. Specifically when dealing with external libraries such as formik where you do onRealValueChange={formik.handleChange} rather than having to setFieldValue name, value. This will also prove more extensible in the future.

![CEM-1251-MaskedInput-Fix](https://user-images.githubusercontent.com/29719870/100120165-e16b1300-2e34-11eb-906b-690dc4f690f8.gif)
