### PR TITLE
CEM-1286-Vendors-Navigation-Bar-Molecule

### DIFF
--- a/src/Containers/MiddleCanvas/DualSelectRadio.tsx
+++ b/src/Containers/MiddleCanvas/DualSelectRadio.tsx
@@ -147,15 +147,15 @@ interface SelectContainerProps {
 };
 const SelectContainer = styled.div<SelectContainerProps>`
     ${scroll};
-    ${({ theme, isVisible }): string => `
-        border: ${isVisible ? `solid 1px ${theme.colors.input.default}` : ''};
-        background-color: ${isVisible ? theme.colors.background : ''};
-        ${isVisible ? media(
+    width: 29%;
+    ${media(
         'tablet',
         `
-            width: 95%;
-            height: 220px;
-        `) : '180px'}; 
+            width: 95%
+        `)}; 
+    ${({ theme, isVisible }): string | false | undefined => isVisible &&`
+        border: 1px solid ${theme.colors.input.default};
+        background-color: ${theme.colors.background};
     `}
     border-radius: 8px;
     position: absolute;

--- a/src/Containers/VendorsList/NavigationBar.tsx
+++ b/src/Containers/VendorsList/NavigationBar.tsx
@@ -42,7 +42,7 @@ export const NavigationBar: React.FC<INavigationBarProps> = ({
 
 const Wrapper = styled.div`
     ${flex('row')};
-    ${({ theme }) => `
+    ${({ theme }): string => `
         border-bottom: 2px solid ${theme.colors.input.default};
     `};
     ${media(

--- a/src/Containers/VendorsList/NavigationBar.tsx
+++ b/src/Containers/VendorsList/NavigationBar.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { StyledIcon } from '@styled-icons/styled-icon';
+import { NavigationItem, INavigationItemProps } from './NavigationItem';
+import { MainInterface, ResponsiveInterface } from '../../Utils/BaseStyles';
+import { flex, media, scroll } from '../../Utils/Mixins';
+
+
+export interface INavigationBarItems {
+    icon?: StyledIcon;
+    label: string
+};
+
+export interface INavigationBarProps extends MainInterface, ResponsiveInterface, React.HTMLAttributes<HTMLDivElement> {
+    navigationBarItems: INavigationBarItems[];
+    navigationItemProps?: INavigationItemProps;
+};
+
+const FIRST_LABEL = 0;
+
+export const NavigationBar: React.FC<INavigationBarProps> = ({
+    navigationBarItems,
+    navigationItemProps,
+    ...props
+}): React.ReactElement => {
+    const [selectedItem, setSelectedItem] = useState(navigationBarItems[FIRST_LABEL].label);
+    return (
+        <Wrapper {...props}>
+            {navigationBarItems.map(item => (
+                <NavigationItem 
+                    {...navigationItemProps}
+                    key={item.label}
+                    icon={item.icon}
+                    label={item.label}
+                    selectedItem={selectedItem}
+                    onClick={() => setSelectedItem(item.label)}
+                />
+            ))}
+        </Wrapper>
+    );
+};
+
+const Wrapper = styled.div`
+    ${flex('row')};
+    ${({ theme }) => `
+        border-bottom: 2px solid ${theme.colors.input.default};
+    `};
+    ${media(
+        'phone',
+        `
+        ${flex('column', 'center')};
+        ${scroll};
+    `)};
+`;

--- a/src/Containers/VendorsList/NavigationBar.tsx
+++ b/src/Containers/VendorsList/NavigationBar.tsx
@@ -1,18 +1,11 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { StyledIcon } from '@styled-icons/styled-icon';
 import { NavigationItem, INavigationItemProps } from './NavigationItem';
 import { MainInterface, ResponsiveInterface } from '../../Utils/BaseStyles';
 import { flex, media, scroll } from '../../Utils/Mixins';
 
-
-export interface INavigationBarItems {
-    icon?: StyledIcon;
-    label: string
-};
-
 export interface INavigationBarProps extends MainInterface, ResponsiveInterface, React.HTMLAttributes<HTMLDivElement> {
-    navigationBarItems: INavigationBarItems[];
+    navigationBarItems: INavigationItemProps[];
     navigationItemProps?: INavigationItemProps;
 };
 
@@ -23,7 +16,7 @@ export const NavigationBar: React.FC<INavigationBarProps> = ({
     navigationItemProps,
     ...props
 }): React.ReactElement => {
-    const [selectedItem, setSelectedItem] = useState(navigationBarItems[FIRST_LABEL].label);
+    const [selectedItem, setSelectedItem] = useState<string>(navigationBarItems[FIRST_LABEL]?.label);
     return (
         <Wrapper {...props}>
             {navigationBarItems.map(item => (
@@ -33,7 +26,7 @@ export const NavigationBar: React.FC<INavigationBarProps> = ({
                     icon={item.icon}
                     label={item.label}
                     selectedItem={selectedItem}
-                    onClick={() => setSelectedItem(item.label)}
+                    onClick={(): void => setSelectedItem(item.label)}
                 />
             ))}
         </Wrapper>

--- a/src/Containers/VendorsList/NavigationItem.tsx
+++ b/src/Containers/VendorsList/NavigationItem.tsx
@@ -8,9 +8,8 @@ import { flex } from '../../Utils/Mixins';
 export interface INavigationItemProps extends MainInterface, ResponsiveInterface, React.HTMLAttributes<HTMLDivElement> {
     icon?: StyledIcon,
     label: string,
-    selectedItem: string,
+    selectedItem?: string,
     headingProps?: HeadingProps,
-    iconProps?: IIconProps,
 };
 
 export const NavigationItem: React.FC<INavigationItemProps> = ({
@@ -18,12 +17,11 @@ export const NavigationItem: React.FC<INavigationItemProps> = ({
     label,
     selectedItem,
     headingProps,
-    iconProps,
     ...props
 }): React.ReactElement => {
     return (
-        <Wrapper isSelected={selectedItem === label} {...props}>
-            <Icon as={icon} {...iconProps} />
+        <Wrapper selectedItem={selectedItem} label={label} {...props}>
+            <Icon as={icon} />
             <Heading type='h6' {...headingProps}>
                 {label}
             </Heading>
@@ -31,17 +29,13 @@ export const NavigationItem: React.FC<INavigationItemProps> = ({
     );
 };
 
-interface IWrapperProps{
-    isSelected: boolean
-};
-const Wrapper = styled.div<IWrapperProps>`
+const Wrapper = styled.div<Pick<INavigationItemProps, 'selectedItem' | 'label'>>`
     ${flex('row')};
-    ${({ theme, isSelected }): string => `
-        border-bottom: ${isSelected ? `solid 4px ${theme.colors.primary}` : ''};
+    ${({ theme, selectedItem, label }): string | false => selectedItem === label &&`
+        border-bottom: solid 3px ${theme.colors.primary};
     `};
 `;
 
-interface IIconProps {};
 const Icon = styled.svg`
     width: 30px;
     height: 30px;

--- a/src/Containers/VendorsList/NavigationItem.tsx
+++ b/src/Containers/VendorsList/NavigationItem.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import styled from 'styled-components';
+import { StyledIcon } from '@styled-icons/styled-icon';
+import { Heading, HeadingProps } from '../../Text/Heading';
+import { MainInterface, ResponsiveInterface } from '../../Utils/BaseStyles';
+import { flex } from '../../Utils/Mixins';
+
+export interface INavigationItemProps extends MainInterface, ResponsiveInterface, React.HTMLAttributes<HTMLDivElement> {
+    icon?: StyledIcon,
+    label: string,
+    selectedItem: string,
+    headingProps?: HeadingProps,
+    iconProps?: IIconProps,
+};
+
+export const NavigationItem: React.FC<INavigationItemProps> = ({
+    icon,
+    label,
+    selectedItem,
+    headingProps,
+    iconProps,
+    ...props
+}): React.ReactElement => {
+    return (
+        <Wrapper isSelected={selectedItem === label} {...props}>
+            <Icon as={icon} {...iconProps} />
+            <Heading type='h6' {...headingProps}>
+                {label}
+            </Heading>
+        </Wrapper>
+    );
+};
+
+interface IWrapperProps{
+    isSelected: boolean
+};
+const Wrapper = styled.div<IWrapperProps>`
+    ${flex('row')};
+    ${({ theme, isSelected }) => `
+        border-bottom: ${isSelected ? `solid 4px ${theme.colors.primary}` : ''};
+    `}
+`;
+
+interface IIconProps {};
+const Icon = styled.svg`
+    width: 30px;
+    height: 30px;
+`;

--- a/src/Containers/VendorsList/NavigationItem.tsx
+++ b/src/Containers/VendorsList/NavigationItem.tsx
@@ -36,9 +36,9 @@ interface IWrapperProps{
 };
 const Wrapper = styled.div<IWrapperProps>`
     ${flex('row')};
-    ${({ theme, isSelected }) => `
+    ${({ theme, isSelected }): string => `
         border-bottom: ${isSelected ? `solid 4px ${theme.colors.primary}` : ''};
-    `}
+    `};
 `;
 
 interface IIconProps {};

--- a/src/Containers/VendorsList/VendorsHeader.tsx
+++ b/src/Containers/VendorsList/VendorsHeader.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Button, ButtonProps } from '../../Inputs/Button';
 import { Heading } from '../../Text/Heading';
 import { MainInterface, ResponsiveInterface } from '../../Utils/BaseStyles';
-import { flex } from '../../Utils/Mixins';
+import { flex, media } from '../../Utils/Mixins';
 
 export interface IVendorsHeaderProps
     extends MainInterface,
@@ -39,6 +39,11 @@ export const VendorsHeader: React.FC<IVendorsHeaderProps> = ({
 
 const Wrapper = styled.div`
     ${flex('row', 'space-between')};
+    ${media(
+        'phone',
+        `
+        ${flex('column', 'center')};
+    `)};
 `;
 const Row = styled.div`
     ${flex('row')};

--- a/src/Containers/VendorsList/index.ts
+++ b/src/Containers/VendorsList/index.ts
@@ -1,1 +1,2 @@
 export * from './VendorsHeader';
+export * from './NavigationBar';

--- a/stories/Containers/VendorsNavigationBar.stories.tsx
+++ b/stories/Containers/VendorsNavigationBar.stories.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { TableView } from '@styled-icons/material/TableView';
+import { List } from '@styled-icons/bootstrap/List';
+import { ViewGrid } from '@styled-icons/heroicons-solid/ViewGrid';
+import { NavigationBar, INavigationBarProps } from '../../src';
+import { createStoryTitle } from '../Constants';
+import { Story, Meta } from '@storybook/react';
+
+export default {
+    title: createStoryTitle('Vendors Navigation Bar'),
+    component: NavigationBar,
+} as Meta;
+
+const getVendorNavigationBarProps = () => ({
+    navigationBarItems: [
+        {
+            icon: TableView,
+            label: 'Overview'
+        },
+        {
+            icon: List,
+            label: 'List View'
+        },
+        {
+            icon: ViewGrid,
+            label: 'Segment'
+        }
+    ],
+    navigationItemProps: {
+        style: {
+            margin: '0 20px',
+            paddingBottom: '5px'
+        },
+        iconProps: {
+            style: {
+                paddingRight: '5px'
+            }
+        }
+    },
+});
+
+const Template: Story<INavigationBarProps> = (args) => (
+    <NavigationBar {...args} />
+);
+
+export const Basic = Template.bind({});
+Basic.args = getVendorNavigationBarProps();

--- a/stories/Containers/VendorsNavigationBar.stories.tsx
+++ b/stories/Containers/VendorsNavigationBar.stories.tsx
@@ -29,7 +29,7 @@ const getVendorNavigationBarProps = () => ({
     navigationItemProps: {
         style: {
             margin: '0 20px',
-            paddingBottom: '5px'
+            paddingBottom: '5px', 
         },
         iconProps: {
             style: {


### PR DESCRIPTION
I added a responsiveness feature from my last ticket (forgot about it).
<img width="726" alt="Screen Shot 2020-12-05 at 6 09 01 PM" src="https://user-images.githubusercontent.com/62865150/101267281-fa24d400-3724-11eb-96c5-7c11e47a37af.png">

Navigation Bar:
![Navigation Bar](http://g.recordit.co/Z7FRb6t16I.gif)

Also would it be correct to call this an organism?