### PR TITLE
CEM-1215-Phone-Number-Mask

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -54,7 +54,7 @@ module.exports = {
         'import/prefer-default-export': 'off',
         'import/extensions': 'off',
         'import/no-extraneous-dependencies': 'off',
-        camelcase: 'off',
+        'camelcase': 'off',
         'no-shadow': 'off',
         'no-use-before-define': [0],
         'no-underscore-dangle': 'off',

--- a/src/Inputs/MaskedInput.tsx
+++ b/src/Inputs/MaskedInput.tsx
@@ -8,7 +8,12 @@ import {
 
 const MINUS_SIGN = '-';
 const MIN_LESS_THAN_ZERO = 0;
+const MASK_LESS_THAN_ZERO = 0;
+const FIRST_CHARACTER = 0;
+const SECOND_CHARACTER = 1;
+const FIX_NUMBER_TO_TWO_DECIMALS = 2;
 const ERROR_MESSAGE_VALUE_CALCULATION = 1;
+const DASH_TO_SEPERATE_PHONE_DIGITS = '-';
 const VALIDATE_INPUT_FORMAT = /^[+-]?(?:\d*\.)?\d+$/gm;
 const PHONE_NUMBER_MATCH = /(?:(?=\d{1,4}$)\d{1,4}$|\d{1,3})/gm
 
@@ -51,10 +56,10 @@ export const MaskedInput: React.FC<MaskedInputProps> = ({
             setIsError('Value cannot be empty');
             return '';
         }
-        if (number < 0) {
-            return `-$${-number.toFixed(2)}`;
+        if (number < MASK_LESS_THAN_ZERO) {
+            return `-$${-number.toFixed(FIX_NUMBER_TO_TWO_DECIMALS)}`;
         }
-        return `$${number.toFixed(2)}`;
+        return `$${number.toFixed(FIX_NUMBER_TO_TWO_DECIMALS)}`;
     };
 
     const PERCENT_FORMAT_MASK = (s: string): string => {
@@ -63,18 +68,21 @@ export const MaskedInput: React.FC<MaskedInputProps> = ({
             setIsError('Value cannot be empty');
             return '';
         }
-        if (number < 0) {
-            return `-${-number.toFixed(2)}%`;
+        if (number < MASK_LESS_THAN_ZERO) {
+            return `-${-number.toFixed(FIX_NUMBER_TO_TWO_DECIMALS)}%`;
         }
-        return `${number.toFixed(2)}%`;
+        return `${number.toFixed(FIX_NUMBER_TO_TWO_DECIMALS)}%`;
     };
 
     const PHONE_FORMAT_MASK = (s: string): string => {
-        const firstDigit = s.slice(0,1);
-        const phoneNumberToMatch = s.slice(1);
+        const firstDigit = s.slice(FIRST_CHARACTER,SECOND_CHARACTER);
+        const phoneNumberToMatch = s.slice(SECOND_CHARACTER);
         const phoneNumberFormat = phoneNumberToMatch.match(PHONE_NUMBER_MATCH);
-        if (phoneNumberFormat && firstDigit) {
-            return `${firstDigit}-${phoneNumberFormat?.join('-')}`;
+        if (phoneNumberFormat) {
+            return `${firstDigit}-${phoneNumberFormat.join(DASH_TO_SEPERATE_PHONE_DIGITS)}`;
+        } 
+        if (firstDigit) {
+            return `${firstDigit}`
         }
         return '';
     }

--- a/stories/Inputs/MaskedInput.stories.tsx
+++ b/stories/Inputs/MaskedInput.stories.tsx
@@ -33,6 +33,7 @@ export default {
         description: 'Enter a value',
         min: 1,
         max: 100,
+        error: ''
     },
 } as Meta;
 


### PR DESCRIPTION
MaskedInput did not support exterior error handling, and for errors to display required a min/max value. Now supports exterior error handling and default error handling.

Phone number mask has been added. Will still error for invalid input, but on blur will now display a formatted phone number with the format 1-xxx-xxx-xxxx. 
![CEM-1215-Phone-Number-Mask - Mask Update](https://user-images.githubusercontent.com/29719870/101936443-ce2ea600-3b9d-11eb-949a-3375124f62b4.gif)
![CEM-1215-Phone-Number-Mask](https://user-images.githubusercontent.com/29719870/101936466-d4bd1d80-3b9d-11eb-8ee1-bcfe12a08cba.gif)

