### PR TITLE
CEM-2085 fix visitcount in profilecard position absolute

### DIFF
--- a/src/Containers/ProfileCard/ProfileCard.tsx
+++ b/src/Containers/ProfileCard/ProfileCard.tsx
@@ -76,7 +76,7 @@ const HeartIcon = styled(Heart)`
   stroke: white;
   stroke-width: 2;
   top: 115px;
-  left: 125px;
+  left: 92px;
   z-index: 11;
 `;
 
@@ -86,6 +86,7 @@ const Container = styled.div`
   background-color: white;
   border-radius: 10px;
   box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.25);
+  position:relative;
 `;
 
 const LeftContainer = styled.div`
@@ -124,7 +125,7 @@ const VisitCountContainer = styled.div`
   position: absolute;
   // Height of Photo + Half Height of Self
   top: 115px;
-  left: 40px;
+  left: 33px;
   z-index: 11;
   display: flex;
   align-items: center;


### PR DESCRIPTION
the visitcount in profilecard was positioned absolute which caused to display incorrectly when using in dashboard terminal. adding a position:relative in the parent container should solve the issue (in theory).
<img width="657" alt="Screenshot 2021-02-18 at 11 24 15" src="https://user-images.githubusercontent.com/29568460/108343163-ed6c3400-71db-11eb-82e8-43b387e6884f.png">
