### PR TITLE
fixing minwidth in input in searchbar expandable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cheapreats/react-ui",
-    "version": "2.3.82",
+    "version": "2.3.83",
     "description": "React UI library for CheaprEats",
     "main": "dist/index.js",
     "module": "dist/index.es.js",

--- a/src/Inputs/SearchBarExpandable/SearchBarExpandable.tsx
+++ b/src/Inputs/SearchBarExpandable/SearchBarExpandable.tsx
@@ -125,6 +125,7 @@ interface IInputFragmentProps{
 }
 
 const InputFragment = styled(I)<IInputFragmentProps>`
+    min-width:0;
     flex-grow: 1;
     ${({isExpanded}):string=>`
     width:${isExpanded?EXPANDED_WIDTH:NOT_EXPANDED_WIDTH}px;


### PR DESCRIPTION
the input field inside SearchBarExpandable had a minimum width which make icon on the right go outside of the box. setting it to 0 solved the problem.
![Captura de pantalla 2021-03-04 a las 19 34 02](https://user-images.githubusercontent.com/29568460/110012227-9d838600-7d20-11eb-8df0-d9bb8d73f17d.png)
