### PR TITLE
CEM-2329 Fix Search Bar

### DIFF
--- a/src/Containers/List/List.stories.tsx
+++ b/src/Containers/List/List.stories.tsx
@@ -42,7 +42,7 @@ export default {
     args: {
         header: (
             <ListHeader
-                label="List Header"
+                label="Header"
                 headerFlex="space-between"
                 icon={COG_WHEEL_ICON}
                 iconProps="width: 20px; margin-right: 10px;"
@@ -75,14 +75,18 @@ export const ListHeaderWithSearchBar: Story<ListHeaderProps> = (args) => (
 );
 
 ListHeaderWithSearchBar.args = {
-    label: 'List Header',
+    label: 'Header',
     headerFlex: 'space-between',
     icon: COG_WHEEL_ICON,
-    iconProps: 'width: 20px; margin: 0 10px;',
+    iconProps: 'width: 20px; margin-left: 10px;',
     iconClick: () => alert('Icon Clicked'),
     onSearch: (value: string) => {
         console.log(value);
     },
+    searchBarWidth: '80vw',
+    searchBarMediaQuery: 'phone',
+    searchBarMediaWidth: '70vw '
+
 };
 
 export const Basic: Story<ListProps> = (args) => {

--- a/src/Containers/List/List.tsx
+++ b/src/Containers/List/List.tsx
@@ -104,7 +104,7 @@ interface ColumnProps {
 
 const Wrapper = styled.div<WrapperProps>`
     ${Mixins.flex()}
-    ${Mixins.transition(['transform'])} 
+    ${Mixins.transition(['transform'])}
     height: 100%;
     ${({
         isOpen,

--- a/src/Containers/List/ListHeader.tsx
+++ b/src/Containers/List/ListHeader.tsx
@@ -1,12 +1,10 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { StyledIcon } from '@styled-icons/styled-icon';
 import { SearchBarExpandable } from '../../Inputs/SearchBarExpandable/SearchBarExpandable';
 import { Heading } from '../../Text/Heading';
 import { TextLayoutProps } from '../../__Layouts';
 import { Mixins } from '../../Utils';
-
-const DELAY = 1000;
 
 export interface ListHeaderProps extends TextLayoutProps {
     label?: string;
@@ -19,6 +17,9 @@ export interface ListHeaderProps extends TextLayoutProps {
     padding?: string;
     margin?: string;
     onSearch?: (value: string) => void;
+    searchBarWidth?: string;
+    searchBarMediaQuery?: string;
+    searchBarMediaWidth?: string;
     onClose?: () => void;
 }
 
@@ -30,6 +31,9 @@ export const ListHeader: React.FC<ListHeaderProps> = ({
     iconClick,
     iconProps,
     headerRowComponent,
+    searchBarWidth,
+    searchBarMediaQuery,
+    searchBarMediaWidth,
     padding = '10px 20px;',
     margin = '0',
     onSearch,
@@ -37,63 +41,70 @@ export const ListHeader: React.FC<ListHeaderProps> = ({
     ...props
 }): React.ReactElement => {
     const [isExpanded, setIsExpanded] = useState(false);
-    const [showRest, setShowRest] = useState(true);
-
-    /**
-     * delay the appearence of the rest of elements when the SearchBar is contracted
-     * due to the delay in contraction
-     */
-    useEffect(() => {
-        if (!isExpanded) {
-            setTimeout(() => {
-                setShowRest(true);
-            }, DELAY);
-        } else {
-            setShowRest(false);
-        }
-    }, [isExpanded, setShowRest]);
 
     return (
-        <Header padding={padding} margin={margin} {...props}>
+        <ListHeaderContainer padding={padding} margin={margin} {...props}>
             <Row display={headerFlex}>
-                {showRest && (
-                    <Heading bold type="h2" margin="0 0 5px" {...props}>
+                <HeadingContainer isExpanded={isExpanded}>
+                    <Heading bold type="h2" {...props}>
                         {label}
                     </Heading>
-                )}
-                {onSearch && (
-                    <SearchBarExpandable
-                        onInput={onSearch}
-                        state={[isExpanded, setIsExpanded]}
-                        onClose={onClose}
-                    />
-                )}
-                {icon && showRest && (
-                    <IconContainer>
-                        <Icon
-                            as={icon}
-                            onClick={iconClick}
-                            iconProps={iconProps}
+                </HeadingContainer>
+                <SearchContainer isExpanded={isExpanded}>
+                    {onSearch && (
+                        <SearchBarExpandable
+                            onInput={onSearch}
+                            state={[isExpanded, setIsExpanded]}
+                            onClose={onClose}
+                            expandedWidth={searchBarWidth}
+                            mediaQuery={searchBarMediaQuery}
+                            mediaWidth={searchBarMediaWidth}
                         />
-                    </IconContainer>
-                )}
+                    )}
+                    {icon && (
+                        <IconContainer isExpanded={isExpanded}>
+                            <Icon
+                                as={icon}
+                                onClick={iconClick}
+                                iconProps={iconProps}
+                            />
+                        </IconContainer>
+                    )}
+                </SearchContainer>
                 {headerRowComponent}
             </Row>
             {children}
-        </Header>
+        </ListHeaderContainer>
     );
 };
 
-const IconContainer = styled.div`
+interface IResponsiveSearchProps {
+    isExpanded: boolean; 
+}
+
+const SearchContainer = styled.div<IResponsiveSearchProps>`
+    ${Mixins.flex('row')}
+    margin-left: auto;
+`
+
+const IconContainer = styled.div<IResponsiveSearchProps>`
     ${Mixins.flex('center')}
+    margin-left: 5px;
+
 `;
+const HeadingContainer = styled.div<IResponsiveSearchProps>`
+    ${Mixins.transition(['transform', 'opacity'])}
+    ${({isExpanded}) => isExpanded ? 'transform: translateY(-200px); opacity: 0; position: fixed;' : 'opacity: 1;'}
+`
 
 interface HeaderProps {
     padding?: string;
     margin?: string;
+    
 }
 
-const Header = styled.div<HeaderProps>`
+const ListHeaderContainer = styled.div<HeaderProps>`
+    
     ${({ theme, padding, margin }): string => `
     border-bottom: 2px solid ${theme.colors.text}20;
     padding: ${padding};
@@ -103,6 +114,7 @@ const Header = styled.div<HeaderProps>`
 
 interface RowProps {
     display?: string;
+    
 }
 
 const Row = styled.div<RowProps>`
@@ -115,6 +127,6 @@ interface IconProps {
 }
 
 const Icon = styled.svg<IconProps>`
-    ${(props): string | undefined => props.iconProps}
+    ${(props): string | undefined => props.iconProps};
     cursor:pointer;
 `;

--- a/src/Inputs/SearchBarExpandable/SearchBarExpandable.stories.tsx
+++ b/src/Inputs/SearchBarExpandable/SearchBarExpandable.stories.tsx
@@ -20,6 +20,8 @@ export default {
     },
     args: {
         placeholder: 'placeholder',
+        mediaQuery: 'tablet',
+        mediaWidth: '300px'
     },
 } as Meta;
 


### PR DESCRIPTION
Interesting way to implement this.

Added transitions to ListHeader with search bar instead of removing the element from the dom.

The previous implementation for the search bar was a hack. Now searchbar has a width and an additonal media query.
![Expandable searcj](https://user-images.githubusercontent.com/29719870/112064091-a85f5880-8b1f-11eb-8951-f97c2ca9b812.gif)

