### PR TITLE
upgrade babel-plugin-recharts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@cheapreats/react-ui",
-    "version": "2.3.90",
+    "version": "2.3.91",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@cheapreats/react-ui",
-            "version": "2.3.90",
+            "version": "2.3.91",
             "license": "MIT",
             "dependencies": {
                 "@babel/preset-typescript": "^7.12.7",
@@ -23,7 +23,7 @@
                 "@typescript-eslint/eslint-plugin": "^4.11.0",
                 "@typescript-eslint/parser": "^4.11.0",
                 "@zerollup/ts-transform-paths": "^1.7.18",
-                "babel-plugin-recharts": "^1.2.1",
+                "babel-plugin-recharts": "^2.0.0",
                 "babel-plugin-styled-components": "^1.12.0",
                 "babel-plugin-transform-class-properties": "^6.24.1",
                 "babel-runtime": "^6.26.0",
@@ -38,6 +38,7 @@
                 "react-dropzone": "^11.2.4",
                 "react-image-crop": "^8.6.6",
                 "react-lottie": "^1.2.3",
+                "react-responsive-carousel": "^3.2.16",
                 "react-router-dom": "^5.2.0",
                 "react-table": "^7.6.2",
                 "recharts": "^2.0.9",
@@ -163,11 +164,11 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-            "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+            "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
             "dependencies": {
-                "@babel/highlight": "^7.10.4"
+                "@babel/highlight": "^7.12.13"
             }
         },
         "node_modules/@babel/compat-data": {
@@ -227,11 +228,11 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
-            "integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
+            "version": "7.13.9",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
+            "integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
             "dependencies": {
-                "@babel/types": "^7.12.11",
+                "@babel/types": "^7.13.0",
                 "jsesc": "^2.5.1",
                 "source-map": "^0.5.0"
             }
@@ -318,21 +319,21 @@
             }
         },
         "node_modules/@babel/helper-function-name": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
-            "integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+            "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
             "dependencies": {
-                "@babel/helper-get-function-arity": "^7.12.10",
-                "@babel/template": "^7.12.7",
-                "@babel/types": "^7.12.11"
+                "@babel/helper-get-function-arity": "^7.12.13",
+                "@babel/template": "^7.12.13",
+                "@babel/types": "^7.12.13"
             }
         },
         "node_modules/@babel/helper-get-function-arity": {
-            "version": "7.12.10",
-            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
-            "integrity": "sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==",
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+            "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
             "dependencies": {
-                "@babel/types": "^7.12.10"
+                "@babel/types": "^7.12.13"
             }
         },
         "node_modules/@babel/helper-hoist-variables": {
@@ -431,11 +432,11 @@
             }
         },
         "node_modules/@babel/helper-split-export-declaration": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
-            "integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+            "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
             "dependencies": {
-                "@babel/types": "^7.12.11"
+                "@babel/types": "^7.12.13"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
@@ -472,19 +473,19 @@
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-            "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+            "version": "7.13.10",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+            "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.10.4",
+                "@babel/helper-validator-identifier": "^7.12.11",
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
-            "integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
+            "version": "7.13.13",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
+            "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -1468,35 +1469,34 @@
             "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
         },
         "node_modules/@babel/template": {
-            "version": "7.12.7",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
-            "integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+            "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
             "dependencies": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/parser": "^7.12.7",
-                "@babel/types": "^7.12.7"
+                "@babel/code-frame": "^7.12.13",
+                "@babel/parser": "^7.12.13",
+                "@babel/types": "^7.12.13"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.12.12",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.12.tgz",
-            "integrity": "sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==",
+            "version": "7.13.13",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
+            "integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
             "dependencies": {
-                "@babel/code-frame": "^7.12.11",
-                "@babel/generator": "^7.12.11",
-                "@babel/helper-function-name": "^7.12.11",
-                "@babel/helper-split-export-declaration": "^7.12.11",
-                "@babel/parser": "^7.12.11",
-                "@babel/types": "^7.12.12",
+                "@babel/code-frame": "^7.12.13",
+                "@babel/generator": "^7.13.9",
+                "@babel/helper-function-name": "^7.12.13",
+                "@babel/helper-split-export-declaration": "^7.12.13",
+                "@babel/parser": "^7.13.13",
+                "@babel/types": "^7.13.13",
                 "debug": "^4.1.0",
-                "globals": "^11.1.0",
-                "lodash": "^4.17.19"
+                "globals": "^11.1.0"
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.12.12",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
-            "integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+            "version": "7.13.14",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+            "integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.12.11",
                 "lodash": "^4.17.19",
@@ -6703,13 +6703,13 @@
             }
         },
         "node_modules/babel-plugin-recharts": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-recharts/-/babel-plugin-recharts-1.2.1.tgz",
-            "integrity": "sha512-bIPmjP3TrF2RJk0jDBG+91aTVyLuK48T4Nqekvs/B6MdzPmHXBKB+q+8xXCSRth08Wck+X5ylgSTcr3Ab1egvw==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-recharts/-/babel-plugin-recharts-2.0.0.tgz",
+            "integrity": "sha512-UbIdV9ER+jWgX5QVHMuv7L85u+0R+wSh8mJdoHZ6R1cRn/uYdcDwB99qfc7EBr7m2HrxIuew4bnfXL+b40OTCQ==",
             "dependencies": {
-                "@babel/traverse": "^7.1.0",
-                "@babel/types": "^7.1.0",
-                "babylon": "^6.18.0"
+                "@babel/parser": "^7.13.10",
+                "@babel/traverse": "^7.13.0",
+                "@babel/types": "^7.13.0"
             }
         },
         "node_modules/babel-plugin-styled-components": {
@@ -25161,6 +25161,17 @@
                 "node": ">= 10"
             }
         },
+        "node_modules/react-easy-swipe": {
+            "version": "0.0.21",
+            "resolved": "https://registry.npmjs.org/react-easy-swipe/-/react-easy-swipe-0.0.21.tgz",
+            "integrity": "sha512-OeR2jAxdoqUMHIn/nS9fgreI5hSpgGoL5ezdal4+oO7YSSgJR8ga+PkYGJrSrJ9MKlPcQjMQXnketrD7WNmNsg==",
+            "dependencies": {
+                "prop-types": "^15.5.8"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/react-element-to-jsx-string": {
             "version": "14.3.2",
             "resolved": "https://registry.npmjs.org/react-element-to-jsx-string/-/react-element-to-jsx-string-14.3.2.tgz",
@@ -25328,6 +25339,16 @@
             "peerDependencies": {
                 "react": "^16.0.0 || ^17.0.0",
                 "react-dom": "^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/react-responsive-carousel": {
+            "version": "3.2.18",
+            "resolved": "https://registry.npmjs.org/react-responsive-carousel/-/react-responsive-carousel-3.2.18.tgz",
+            "integrity": "sha512-A6eXp/HofjZ8p23Q/b25dqtokHFFXKhKKn82ZJkCI0edxjtAUid8SImr8rHp0rRi9aEYXej3ynWOzaUHFE4RKA==",
+            "dependencies": {
+                "classnames": "^2.2.5",
+                "prop-types": "^15.5.8",
+                "react-easy-swipe": "^0.0.21"
             }
         },
         "node_modules/react-router": {
@@ -30550,11 +30571,11 @@
             }
         },
         "@babel/code-frame": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-            "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+            "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
             "requires": {
-                "@babel/highlight": "^7.10.4"
+                "@babel/highlight": "^7.12.13"
             }
         },
         "@babel/compat-data": {
@@ -30604,11 +30625,11 @@
             }
         },
         "@babel/generator": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
-            "integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
+            "version": "7.13.9",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
+            "integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
             "requires": {
-                "@babel/types": "^7.12.11",
+                "@babel/types": "^7.13.0",
                 "jsesc": "^2.5.1",
                 "source-map": "^0.5.0"
             }
@@ -30694,21 +30715,21 @@
             }
         },
         "@babel/helper-function-name": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
-            "integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+            "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
             "requires": {
-                "@babel/helper-get-function-arity": "^7.12.10",
-                "@babel/template": "^7.12.7",
-                "@babel/types": "^7.12.11"
+                "@babel/helper-get-function-arity": "^7.12.13",
+                "@babel/template": "^7.12.13",
+                "@babel/types": "^7.12.13"
             }
         },
         "@babel/helper-get-function-arity": {
-            "version": "7.12.10",
-            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
-            "integrity": "sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==",
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+            "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
             "requires": {
-                "@babel/types": "^7.12.10"
+                "@babel/types": "^7.12.13"
             }
         },
         "@babel/helper-hoist-variables": {
@@ -30807,11 +30828,11 @@
             }
         },
         "@babel/helper-split-export-declaration": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
-            "integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+            "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
             "requires": {
-                "@babel/types": "^7.12.11"
+                "@babel/types": "^7.12.13"
             }
         },
         "@babel/helper-validator-identifier": {
@@ -30848,19 +30869,19 @@
             }
         },
         "@babel/highlight": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-            "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+            "version": "7.13.10",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+            "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
             "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
+                "@babel/helper-validator-identifier": "^7.12.11",
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
             }
         },
         "@babel/parser": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
-            "integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg=="
+            "version": "7.13.13",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
+            "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw=="
         },
         "@babel/plugin-proposal-async-generator-functions": {
             "version": "7.12.12",
@@ -31813,35 +31834,34 @@
             }
         },
         "@babel/template": {
-            "version": "7.12.7",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
-            "integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+            "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
             "requires": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/parser": "^7.12.7",
-                "@babel/types": "^7.12.7"
+                "@babel/code-frame": "^7.12.13",
+                "@babel/parser": "^7.12.13",
+                "@babel/types": "^7.12.13"
             }
         },
         "@babel/traverse": {
-            "version": "7.12.12",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.12.tgz",
-            "integrity": "sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==",
+            "version": "7.13.13",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
+            "integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
             "requires": {
-                "@babel/code-frame": "^7.12.11",
-                "@babel/generator": "^7.12.11",
-                "@babel/helper-function-name": "^7.12.11",
-                "@babel/helper-split-export-declaration": "^7.12.11",
-                "@babel/parser": "^7.12.11",
-                "@babel/types": "^7.12.12",
+                "@babel/code-frame": "^7.12.13",
+                "@babel/generator": "^7.13.9",
+                "@babel/helper-function-name": "^7.12.13",
+                "@babel/helper-split-export-declaration": "^7.12.13",
+                "@babel/parser": "^7.13.13",
+                "@babel/types": "^7.13.13",
                 "debug": "^4.1.0",
-                "globals": "^11.1.0",
-                "lodash": "^4.17.19"
+                "globals": "^11.1.0"
             }
         },
         "@babel/types": {
-            "version": "7.12.12",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
-            "integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+            "version": "7.13.14",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+            "integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
             "requires": {
                 "@babel/helper-validator-identifier": "^7.12.11",
                 "lodash": "^4.17.19",
@@ -36532,13 +36552,13 @@
             }
         },
         "babel-plugin-recharts": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-recharts/-/babel-plugin-recharts-1.2.1.tgz",
-            "integrity": "sha512-bIPmjP3TrF2RJk0jDBG+91aTVyLuK48T4Nqekvs/B6MdzPmHXBKB+q+8xXCSRth08Wck+X5ylgSTcr3Ab1egvw==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-recharts/-/babel-plugin-recharts-2.0.0.tgz",
+            "integrity": "sha512-UbIdV9ER+jWgX5QVHMuv7L85u+0R+wSh8mJdoHZ6R1cRn/uYdcDwB99qfc7EBr7m2HrxIuew4bnfXL+b40OTCQ==",
             "requires": {
-                "@babel/traverse": "^7.1.0",
-                "@babel/types": "^7.1.0",
-                "babylon": "^6.18.0"
+                "@babel/parser": "^7.13.10",
+                "@babel/traverse": "^7.13.0",
+                "@babel/types": "^7.13.0"
             }
         },
         "babel-plugin-styled-components": {
@@ -51316,6 +51336,14 @@
                 "prop-types": "^15.7.2"
             }
         },
+        "react-easy-swipe": {
+            "version": "0.0.21",
+            "resolved": "https://registry.npmjs.org/react-easy-swipe/-/react-easy-swipe-0.0.21.tgz",
+            "integrity": "sha512-OeR2jAxdoqUMHIn/nS9fgreI5hSpgGoL5ezdal4+oO7YSSgJR8ga+PkYGJrSrJ9MKlPcQjMQXnketrD7WNmNsg==",
+            "requires": {
+                "prop-types": "^15.5.8"
+            }
+        },
         "react-element-to-jsx-string": {
             "version": "14.3.2",
             "resolved": "https://registry.npmjs.org/react-element-to-jsx-string/-/react-element-to-jsx-string-14.3.2.tgz",
@@ -51478,6 +51506,16 @@
                 "lodash.debounce": "^4.0.8",
                 "lodash.throttle": "^4.1.1",
                 "resize-observer-polyfill": "^1.5.1"
+            }
+        },
+        "react-responsive-carousel": {
+            "version": "3.2.18",
+            "resolved": "https://registry.npmjs.org/react-responsive-carousel/-/react-responsive-carousel-3.2.18.tgz",
+            "integrity": "sha512-A6eXp/HofjZ8p23Q/b25dqtokHFFXKhKKn82ZJkCI0edxjtAUid8SImr8rHp0rRi9aEYXej3ynWOzaUHFE4RKA==",
+            "requires": {
+                "classnames": "^2.2.5",
+                "prop-types": "^15.5.8",
+                "react-easy-swipe": "^0.0.21"
             }
         },
         "react-router": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19579,6 +19579,7 @@
         },
         "node_modules/npm/node_modules/lodash._baseindexof": {
             "version": "3.1.0",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT"
         },
@@ -19593,16 +19594,19 @@
         },
         "node_modules/npm/node_modules/lodash._bindcallback": {
             "version": "3.0.1",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/lodash._cacheindexof": {
             "version": "3.0.2",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/lodash._createcache": {
             "version": "3.1.2",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -19616,6 +19620,7 @@
         },
         "node_modules/npm/node_modules/lodash._getnative": {
             "version": "3.9.1",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT"
         },
@@ -19631,6 +19636,7 @@
         },
         "node_modules/npm/node_modules/lodash.restparam": {
             "version": "3.6.1",
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT"
         },
@@ -46910,7 +46916,8 @@
                 },
                 "lodash._baseindexof": {
                     "version": "3.1.0",
-                    "bundled": true
+                    "bundled": true,
+                    "extraneous": true
                 },
                 "lodash._baseuniq": {
                     "version": "4.6.0",
@@ -46922,15 +46929,18 @@
                 },
                 "lodash._bindcallback": {
                     "version": "3.0.1",
-                    "bundled": true
+                    "bundled": true,
+                    "extraneous": true
                 },
                 "lodash._cacheindexof": {
                     "version": "3.0.2",
-                    "bundled": true
+                    "bundled": true,
+                    "extraneous": true
                 },
                 "lodash._createcache": {
                     "version": "3.1.2",
                     "bundled": true,
+                    "extraneous": true,
                     "requires": {
                         "lodash._getnative": "^3.0.0"
                     }
@@ -46941,7 +46951,8 @@
                 },
                 "lodash._getnative": {
                     "version": "3.9.1",
-                    "bundled": true
+                    "bundled": true,
+                    "extraneous": true
                 },
                 "lodash._root": {
                     "version": "3.0.1",
@@ -46953,7 +46964,8 @@
                 },
                 "lodash.restparam": {
                     "version": "3.6.1",
-                    "bundled": true
+                    "bundled": true,
+                    "extraneous": true
                 },
                 "lodash.union": {
                     "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
         "@typescript-eslint/eslint-plugin": "^4.11.0",
         "@typescript-eslint/parser": "^4.11.0",
         "@zerollup/ts-transform-paths": "^1.7.18",
-        "babel-plugin-recharts": "^1.2.1",
+        "babel-plugin-recharts": "^2.0.0",
         "babel-plugin-styled-components": "^1.12.0",
         "babel-plugin-transform-class-properties": "^6.24.1",
         "babel-runtime": "^6.26.0",

--- a/src/Containers/CarouselTestimonial/CarouselTestimonial.tsx
+++ b/src/Containers/CarouselTestimonial/CarouselTestimonial.tsx
@@ -29,7 +29,7 @@ export const CarouselTestimonial: React.FC<ICarouselTestimonialProps> = ({
                 {carouselTitle}
             </TitleDiv>
             <ImageDiv key={carouselImage}>
-                <img src={carouselImage} />
+                <img src={carouselImage} alt='' />
             </ImageDiv>
             <ReviewTextDiv>
                 {review.testimony}


### PR DESCRIPTION
is necessary to upgrade babel-plugin-recharts to last version (2.0.0) in order to storybook load properly (this is because we upgraded to last version of recharts previously)