### PR TITLE
Invite component error fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cheapreats/react-ui",
-    "version": "2.4.22",
+    "version": "2.4.25",
     "description": "React UI library for CheaprEats",
     "main": "dist/index.js",
     "module": "dist/index.es.js",

--- a/src/Containers/InviteComponent/Invite.stories.tsx
+++ b/src/Containers/InviteComponent/Invite.stories.tsx
@@ -8,7 +8,7 @@ export default {
     component: Invite,
 } as Meta;
 
-const args = {
+const defaultArgs = {
     title: 'Invite only',
     heading: 'Request an invitation to Stripe Treasury',
     description:
@@ -53,4 +53,4 @@ const args = {
 };
 
 export const Basic: Story<InviteProps> = (args) => <Invite {...args} />;
-Basic.args = { ...args };
+Basic.args = { ...defaultArgs };

--- a/src/Containers/InviteComponent/Invite.tsx
+++ b/src/Containers/InviteComponent/Invite.tsx
@@ -1,16 +1,17 @@
-import React from 'react';
+import * as Yup from 'yup'; 
 import Button from '@Inputs/Button/Button';
-import Input from '@Inputs/Input/Input';
-import Textarea from '@Inputs/Textarea/Textarea';
 import Heading from '@Text/Heading';
+import Input from '@Inputs/Input/Input';
+import Paragraph from '@Text/Paragraph';
+import React from 'react';
+import SmallText from '@Text/SmallText';
+import Textarea from '@Inputs/Textarea/Textarea';  
 import styled from 'styled-components';
+import { ArrowRight } from '@styled-icons/bootstrap/ArrowRight';
+import { ChevronRight } from '@styled-icons/bootstrap/ChevronRight';
+import { Formik, useField } from 'formik';
 import { action } from '@storybook/addon-actions';
 import { flex, media } from '@Utils/Mixins';
-import { ChevronRight } from '@styled-icons/bootstrap/ChevronRight';
-import { ArrowRight } from '@styled-icons/bootstrap/ArrowRight';
-import { Formik, useField } from 'formik';
-import * as Yup from 'yup';
-import { Paragraph, SmallText } from '../../index';
 
 export interface InviteProps {
     title: string;
@@ -32,8 +33,7 @@ interface InputFieldsProps {
     subLabel?: string;
     name: string;
     type: string;
-    placeholder: string;
-    as?: string;
+    placeholder: string; 
 }
 
 /**

--- a/src/Containers/InviteComponent/Invite.tsx
+++ b/src/Containers/InviteComponent/Invite.tsx
@@ -19,13 +19,7 @@ export interface InviteProps {
     description: string;
     footer: string;
     buttonText: string;
-    inviteArgs: {
-        name: string;
-        label: string;
-        placeholder: string;
-        type: string;
-        subLabel?: string;
-    }[];
+    inviteArgs: InputFieldsProps[];
 }
 
 interface InputFieldsProps {
@@ -40,16 +34,17 @@ interface InputFieldsProps {
  * @param
  * @returns label, sublabel, input props & error message
  */
-const FormRow = ({
+const FormRow: React.FC<InputFieldsProps> = ({
     label,
-    subLabel,
+    subLabel = '',
     type,
     placeholder,
-    ...rest
-}: InputFieldsProps) => {
-    const [field, meta] = useField(rest);
+    name,
+    ...props
+}) => {
+    const [field, meta] = useField(name);
     return (
-        <div {...rest}>
+        <div {...props}>
             {meta.touched && meta.error && (
                 <SmallText color="primary">{meta.error}</SmallText>
             )}


### PR DESCRIPTION
I started from Brian's InviteComponent branch (which includes the code in his open PR that Ralph already approved #359).

My changes were: 
Bumped the version number in package.json.

Invite.tsx:
 
![image](https://user-images.githubusercontent.com/47924253/119057242-fb6b5580-b980-11eb-9748-87935a6b6655.png)
![image](https://user-images.githubusercontent.com/47924253/119057292-0b833500-b981-11eb-95a0-2daa866dbca4.png)

Any other changes you see below were already included in Brian's PR #359.

This should solve the issue. The Invite component is working correctly in Storybook on my end, and the npm tests all cleared.

Let me know if you have any questions.
