### PR TITLE
Highlighted Text Part 3

### DIFF
--- a/src/Containers/HighlightedText/HighlightedText.stories.tsx
+++ b/src/Containers/HighlightedText/HighlightedText.stories.tsx
@@ -49,3 +49,55 @@ export default {
 } as Meta;
 
 export const Basic: Story<HighlightedTextProps> = (args) => <HighlightedText {...args} />;
+
+export const OldText = Basic.bind({});
+OldText.args = {
+    ...OldText.args,
+    labels:
+    [
+        {
+            text: 'Ordering a',
+            isSpecial: false,
+            overrideAge: false,
+        },
+        {
+            text: 'Burger',
+            isSpecial: true,
+            listItemsArgs: [],
+            listItemsBodies: [
+                <ClickableSmallText onClick={action('Burger Clicked.')}>Burger</ClickableSmallText>, 
+                <ClickableSmallText onClick={action('Fries Clicked.')}>Fries</ClickableSmallText>
+            ],
+            overrideAge: false,
+        },
+    ],
+};
+
+export const BothText = Basic.bind({});
+BothText.args = {
+    ...BothText.args,
+    labels:
+    [
+        {
+            text: 'Welcome to Burger Barn.',
+            isSpecial: false,
+            overrideAge: false,
+        },
+        {
+            text: 'Would you like a ',
+            isSpecial: false,
+            overrideAge: true,
+        },
+        {
+            text: 'Burger',
+            isSpecial: true,
+            listItemsArgs: [],
+            listItemsBodies: [
+                <ClickableSmallText onClick={action('Burger Clicked.')}>Burger</ClickableSmallText>, 
+                <ClickableSmallText onClick={action('Fries Clicked.')}>Fries</ClickableSmallText>
+            ],
+            overrideAge: true,
+        },
+    ],
+};
+

--- a/src/Containers/HighlightedText/HighlightedText.stories.tsx
+++ b/src/Containers/HighlightedText/HighlightedText.stories.tsx
@@ -58,7 +58,7 @@ OldText.args = {
         {
             text: 'Ordering a',
             isSpecial: false,
-            overrideAge: false,
+            isOld: 1,
         },
         {
             text: 'Burger',
@@ -68,7 +68,7 @@ OldText.args = {
                 <ClickableSmallText onClick={action('Burger Clicked.')}>Burger</ClickableSmallText>, 
                 <ClickableSmallText onClick={action('Fries Clicked.')}>Fries</ClickableSmallText>
             ],
-            overrideAge: false,
+            isOld: 1,
         },
     ],
 };
@@ -81,12 +81,12 @@ BothText.args = {
         {
             text: 'Welcome to Burger Barn.',
             isSpecial: false,
-            overrideAge: false,
+            isOld: 1,
         },
         {
             text: 'Would you like a ',
             isSpecial: false,
-            overrideAge: true,
+            isOld: 0,
         },
         {
             text: 'Burger',
@@ -96,7 +96,7 @@ BothText.args = {
                 <ClickableSmallText onClick={action('Burger Clicked.')}>Burger</ClickableSmallText>, 
                 <ClickableSmallText onClick={action('Fries Clicked.')}>Fries</ClickableSmallText>
             ],
-            overrideAge: true,
+            isOld: 0,
         },
     ],
 };

--- a/src/Containers/HighlightedText/HighlightedText.stories.tsx
+++ b/src/Containers/HighlightedText/HighlightedText.stories.tsx
@@ -58,7 +58,7 @@ OldText.args = {
         {
             text: 'Ordering a',
             isSpecial: false,
-            isOld: 1,
+            age: 1,
         },
         {
             text: 'Burger',
@@ -68,7 +68,7 @@ OldText.args = {
                 <ClickableSmallText onClick={action('Burger Clicked.')}>Burger</ClickableSmallText>, 
                 <ClickableSmallText onClick={action('Fries Clicked.')}>Fries</ClickableSmallText>
             ],
-            isOld: 1,
+            age: 1,
         },
     ],
 };
@@ -81,12 +81,12 @@ BothText.args = {
         {
             text: 'Welcome to Burger Barn.',
             isSpecial: false,
-            isOld: 1,
+            age: 1,
         },
         {
             text: 'Would you like a ',
             isSpecial: false,
-            isOld: 0,
+            age: 0,
         },
         {
             text: 'Burger',
@@ -96,7 +96,7 @@ BothText.args = {
                 <ClickableSmallText onClick={action('Burger Clicked.')}>Burger</ClickableSmallText>, 
                 <ClickableSmallText onClick={action('Fries Clicked.')}>Fries</ClickableSmallText>
             ],
-            isOld: 0,
+            age: 0,
         },
     ],
 };

--- a/src/Containers/HighlightedText/HighlightedText.tsx
+++ b/src/Containers/HighlightedText/HighlightedText.tsx
@@ -8,6 +8,11 @@ import { TextLayoutProps } from '../../Fragments/TextLayout';
 const newTextOpacity = 1;
 const oldTextOpacity = 0.5;
 
+enum Age{
+    New = 0,
+    Old = 1,
+}
+
 export interface HighlightedString {
     /** contents of the string */
     text: string;
@@ -21,8 +26,8 @@ export interface HighlightedString {
     listItemsArgs?: Array<IDropdownItemProps>;
     /** content of DropdownItems */
     listItemsBodies?: Array<JSX.Element>;
-    /** true to override age as 'new', false to override as 'old'. Leave unfilled for automatic. */
-    overrideAge?: boolean;
+    /** New (0) for opaque text, Old (1) for transparent text. None for automatic */
+    overrideAge?: Age;
 }
 
 // extends line div

--- a/src/Containers/HighlightedText/HighlightedText.tsx
+++ b/src/Containers/HighlightedText/HighlightedText.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import styled from 'styled-components';
 import { ClickableSmallText, SmallText } from '@Text';
 import Dropdown, { IDropdownProps } from '../Dropdown/Dropdown';
@@ -7,11 +7,6 @@ import { TextLayoutProps } from '../../Fragments/TextLayout';
 
 const newTextOpacity = 1;
 const oldTextOpacity = 0.5;
-
-enum Age{
-    New = 0,
-    Old = 1,
-}
 
 export interface HighlightedString {
     /** contents of the string */
@@ -26,8 +21,8 @@ export interface HighlightedString {
     listItemsArgs?: Array<IDropdownItemProps>;
     /** content of DropdownItems */
     listItemsBodies?: Array<JSX.Element>;
-    /** New (0) for opaque text, Old (1) for transparent text. None for automatic */
-    isOld?: Age;
+    /** in [0, 1]; 0 for newest (opaque), 1 for oldest (most transparent). None for automatic */
+    age?: number;
 }
 
 // extends line div
@@ -48,10 +43,12 @@ export const HighlightedText: React.FC<HighlightedTextProps> = ({
     const [numEntries, setNumEntries] = useState(0);
     const [numNewEntries, setNumNewEntries] = useState(0);
 
-    if (labels.length !== numEntries) {
-        setNumNewEntries (labels.length - numEntries)
-        setNumEntries(labels.length)
-    }
+    useEffect(() => {
+        if (labels.length !== numEntries) {
+            setNumNewEntries (labels.length - numEntries)
+            setNumEntries(labels.length)
+        }
+    })
 
     /**
      * construct the element for a special text
@@ -65,12 +62,8 @@ export const HighlightedText: React.FC<HighlightedTextProps> = ({
      */
     const getTextComponent = (label: HighlightedString, index: number): React.ReactElement => {
         let opacity: number;
-        if (label.isOld != null){
-            if (label.isOld == Age.New) {
-                opacity = newTextOpacity
-            } else {
-                opacity = oldTextOpacity
-            }
+        if (label.age != null){
+            opacity = newTextOpacity - label.age*oldTextOpacity
         } else if (index >= labels.length - numNewEntries) {
             opacity = newTextOpacity
         } else {

--- a/src/Containers/HighlightedText/HighlightedText.tsx
+++ b/src/Containers/HighlightedText/HighlightedText.tsx
@@ -5,8 +5,8 @@ import Dropdown, { IDropdownProps } from '../Dropdown/Dropdown';
 import DropdownItem, { IDropdownItemProps } from '../Dropdown/DropdownItem';
 import { TextLayoutProps } from '../../Fragments/TextLayout';
 
-const newTextOpacity: number = 1;
-const oldTextOpacity: number = 0.5;
+const newTextOpacity = 1;
+const oldTextOpacity = 0.5;
 
 export interface HighlightedString {
     /** contents of the string */
@@ -43,7 +43,7 @@ export const HighlightedText: React.FC<HighlightedTextProps> = ({
     const [numEntries, setNumEntries] = useState(0);
     const [numNewEntries, setNumNewEntries] = useState(0);
 
-    if (labels.length != numEntries) {
+    if (labels.length !== numEntries) {
         setNumNewEntries (labels.length - numEntries)
         setNumEntries(labels.length)
     }
@@ -66,12 +66,10 @@ export const HighlightedText: React.FC<HighlightedTextProps> = ({
             } else {
                 opacity = oldTextOpacity
             }
+        } else if (index >= labels.length - numNewEntries) {
+            opacity = newTextOpacity
         } else {
-            if (index >= labels.length - numNewEntries) {
-                opacity = newTextOpacity
-            } else {
-                opacity = oldTextOpacity
-            }
+            opacity = oldTextOpacity
         }
         
         if (label.isSpecial){
@@ -81,9 +79,9 @@ export const HighlightedText: React.FC<HighlightedTextProps> = ({
                 dropdownButton: getSpecialTextComponent(label, opacity),
             }
             return <Dropdown {...DropDownProps} {...label.listProps}>
-                {listItemsBodies.map((_, index) => (
-                    <DropdownItem {...listItemsArgs[index]}>
-                        {listItemsBodies[index]}
+                {listItemsBodies.map((_, i) => (
+                    <DropdownItem {...listItemsArgs[i]}>
+                        {listItemsBodies[i]}
                     </DropdownItem>
                 ))}
             </Dropdown>

--- a/src/Containers/HighlightedText/HighlightedText.tsx
+++ b/src/Containers/HighlightedText/HighlightedText.tsx
@@ -27,7 +27,7 @@ export interface HighlightedString {
     /** content of DropdownItems */
     listItemsBodies?: Array<JSX.Element>;
     /** New (0) for opaque text, Old (1) for transparent text. None for automatic */
-    overrideAge?: Age;
+    isOld?: Age;
 }
 
 // extends line div
@@ -65,8 +65,8 @@ export const HighlightedText: React.FC<HighlightedTextProps> = ({
      */
     const getTextComponent = (label: HighlightedString, index: number): React.ReactElement => {
         let opacity: number;
-        if (label.overrideAge != null){
-            if (label.overrideAge) {
+        if (label.isOld != null){
+            if (label.isOld == Age.New) {
                 opacity = newTextOpacity
             } else {
                 opacity = oldTextOpacity

--- a/src/Containers/HighlightedText/HighlightedText.tsx
+++ b/src/Containers/HighlightedText/HighlightedText.tsx
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, {useState} from 'react';
 import styled from 'styled-components';
 import { ClickableSmallText, SmallText } from '@Text';
 import Dropdown, { IDropdownProps } from '../Dropdown/Dropdown';
 import DropdownItem, { IDropdownItemProps } from '../Dropdown/DropdownItem';
 import { TextLayoutProps } from '../../Fragments/TextLayout';
 
+const newTextOpacity: number = 1;
+const oldTextOpacity: number = 0.5;
 
 export interface HighlightedString {
     /** contents of the string */
@@ -19,6 +21,8 @@ export interface HighlightedString {
     listItemsArgs?: Array<IDropdownItemProps>;
     /** content of DropdownItems */
     listItemsBodies?: Array<JSX.Element>;
+    /** true to override age as 'new', false to override as 'old'. Leave unfilled for automatic. */
+    overrideAge?: boolean;
 }
 
 // extends line div
@@ -36,23 +40,45 @@ export const HighlightedText: React.FC<HighlightedTextProps> = ({
     labels,
     ...props
 }): React.ReactElement => {
+    const [numEntries, setNumEntries] = useState(0);
+    const [numNewEntries, setNumNewEntries] = useState(0);
+
+    if (labels.length != numEntries) {
+        setNumNewEntries (labels.length - numEntries)
+        setNumEntries(labels.length)
+    }
 
     /**
      * construct the element for a special text
      * @param label - HighlightedString of the special text
      */
-    const getSpecialTextComponent = (label: HighlightedString): React.ReactElement => <ClickableSmallText bold {...label.textProps}>{`${label.text  } `}</ClickableSmallText>
+    const getSpecialTextComponent = (label: HighlightedString, opacity: number): React.ReactElement => <ClickableSmallText style={{opacity}} bold {...label.textProps}>{`${label.text  } `}</ClickableSmallText>
 
     /**
      * construct the dropdown or text for a HighlightedString
      * @param label - HighlightedString of the text
      */
-    const getTextComponent = (label: HighlightedString): React.ReactElement => {
+    const getTextComponent = (label: HighlightedString, index: number): React.ReactElement => {
+        let opacity: number;
+        if (label.overrideAge != null){
+            if (label.overrideAge) {
+                opacity = newTextOpacity
+            } else {
+                opacity = oldTextOpacity
+            }
+        } else {
+            if (index >= labels.length - numNewEntries) {
+                opacity = newTextOpacity
+            } else {
+                opacity = oldTextOpacity
+            }
+        }
+        
         if (label.isSpecial){
             const listItemsArgs: Array<IDropdownItemProps> = label.listItemsArgs || []
             const listItemsBodies: Array<JSX.Element> = label.listItemsBodies || []
             const DropDownProps: IDropdownProps = {
-                dropdownButton: getSpecialTextComponent(label),
+                dropdownButton: getSpecialTextComponent(label, opacity),
             }
             return <Dropdown {...DropDownProps} {...label.listProps}>
                 {listItemsBodies.map((_, index) => (
@@ -62,7 +88,7 @@ export const HighlightedText: React.FC<HighlightedTextProps> = ({
                 ))}
             </Dropdown>
         } 
-        return <SmallText {...label.textProps}>{`${label.text  } `}</SmallText>
+        return <SmallText style={{opacity}} {...label.textProps}>{`${label.text  } `}</SmallText>
     }
 
     /**
@@ -70,8 +96,8 @@ export const HighlightedText: React.FC<HighlightedTextProps> = ({
      */
     const renderText = (): React.ReactElement => (
         <p>
-            {labels.map((label) => (
-                getTextComponent(label)
+            {labels.map((label, index) => (
+                getTextComponent(label, index)
             ))}
         </p>
     )


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/43617742/139468117-68429428-b125-4336-aebb-c5a55adc6800.png)

When new text is added to labels, the previous text automatically becomes transparent. The 'age' of text can also be overridden to force them to appear as 'old' or 'new'.