### PR TITLE
CEM-2582 Responsive Tags

### DIFF
--- a/src/Containers/TagGroup/TagGroup.tsx
+++ b/src/Containers/TagGroup/TagGroup.tsx
@@ -3,13 +3,18 @@ import styled from 'styled-components';
 import { Tag, TagProps } from '../Tag/Tag';
 
 const LEFT_MOST_TAG = 0;
+const SINGLE_TAG = 1;
+const FONT_HEIGHT_MOD = 0.8;
+const BOTH_SIDES = 2;
+const PADDING_BUFFER = 3;
 export interface TagGroupProps extends React.HTMLAttributes<HTMLDivElement> {
     /* [{text: value, icon: value}, {text: value, icon: value}] */
     tags: Array<TagProps>;
 };
-
+type positionType = 'left' | 'middle' | 'right';
 interface TagPositionProps extends TagProps {
-    position?: 'left' | 'right';
+    /* Leftmost, rightmost, or middle tag */
+    position?: positionType;
 }
 
 export const TagGroup: React.FC<TagGroupProps> = ({
@@ -21,32 +26,53 @@ export const TagGroup: React.FC<TagGroupProps> = ({
      * @param tagComponents {Array}
      */
     const displayTags = (tagComponents: Array<TagProps>) => {
-        if (tagComponents.length === 1) {
+        if (tagComponents.length === SINGLE_TAG) {
             return <Tag {...tagComponents[0]} />
         }
         return tags.map((tag, index) => {
+            const tagPieceProps = {...tag, position: 'middle' as positionType};
             if (index === LEFT_MOST_TAG ){
-                return <TagPiece {...tag} position='left' />
+                tagPieceProps.position = 'left';
             } 
             if (index === tagComponents.length - 1) {
-                return <TagPiece {...tag} position='right' />
+                tagPieceProps.position = 'right';
             }
-            return <TagPiece {...tag} />
+            return <TagPiece {...tagPieceProps} />
         })
-        
     };
 
     return (
-        <div {...props}> 
-            {displayTags(tags)}
-        </div>
+        <Container {...props}>
+            <SubContainer>
+                {displayTags(tags)}
+            </SubContainer>
+        </Container>
     );
 }
+
+const Container = styled.div`
+    ${({theme}) => `
+        height: calc((${theme.dimensions.tag.fontSize} / ${FONT_HEIGHT_MOD}) + (${theme.dimensions.tag.padding.toString().split(" ")[0]} * ${BOTH_SIDES}) + ${PADDING_BUFFER}px);
+    ` }
+    overflow: hidden;
+`;
+
+const SubContainer = styled.div`
+    white-space: nowrap;
+    height: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding-bottom: 15px;
+    padding-left: 20px;
+    padding-right: 20px;
+    mask-image: linear-gradient(to left, transparent 0, black 30px, black calc(100% - 30px), transparent 100%);
+`;
 
 const TagPiece = styled(Tag)<TagPositionProps>`
     border-radius: ${({position}) => {
         if (position === 'left') {return '999px 0px 0px 999px'}
         if (position === 'right') {return '0px 999px 999px 0px'}
-        return '0px'
+        if (position === 'middle') {return '0px'}
+        return ''
     }};
 `;


### PR DESCRIPTION
Modified the tag group component to be responsive, as well as implementing a fade effect so the user knows to scroll through the tags when applicable.
![image](https://user-images.githubusercontent.com/78105611/140580488-5ec947ff-f025-4a2e-9df2-9c09fad7269f.png)
