### PR TITLE
Mac-LU-CEM2514-Menu Item Card + Loyalty Points

### DIFF
--- a/src/Containers/LimitedTimeBanner/LimitedTimeBanner.stories.tsx
+++ b/src/Containers/LimitedTimeBanner/LimitedTimeBanner.stories.tsx
@@ -7,7 +7,9 @@ export default {
     title: 'Components/LimitedTimeBanner',
     component: LimitedTimeBanner,
     args: {
-        minsRemaining: 120, 
+        minsRemaining: 120,
+        bannerWidth: 300,
+        bannerHeight: 40,
     },
 } as Meta;
 

--- a/src/Containers/LimitedTimeBanner/LimitedTimeBanner.tsx
+++ b/src/Containers/LimitedTimeBanner/LimitedTimeBanner.tsx
@@ -9,14 +9,18 @@ const MINUTES_IN_YEAR = 524160;
 export interface LimitedTimeBannerProps
     extends MainInterface {
         /* minutes until time runs out */ 
-        minsRemaining: number,
+    minsRemaining: number,
+    bannerWidth?: number,
+    bannerHeight?: number,
     }
 
 export const LimitedTimeBanner: React.FC<LimitedTimeBannerProps> = ({
     minsRemaining,
+    bannerWidth,
+    bannerHeight,
     ...props
 }): React.ReactElement => (
-    <BannerBox {...props}>
+    <BannerBox minsRemaining={minsRemaining} bannerWidth={bannerWidth} bannerHeight={bannerHeight} {...props}>
         <Icon />
         <BannerHeader>
             {alterTime(minsRemaining)} Remaining
@@ -47,14 +51,16 @@ const alterTime = (value:number)  => {
     return(moment.duration(value,'minutes').humanize());
 }
 
-const BannerBox = styled.div`
+const BannerBox = styled.div<LimitedTimeBannerProps>`
     ${({theme}):string => `
     font-family: ${theme.font.family};
     color: ${theme.colors.background}};
     background-color:  ${theme.colors.bannerBackgroundColor};
     `}
-    width:350px;
-    height:40px;
+    ${({ bannerWidth, bannerHeight }): string => `
+    width: ${bannerWidth}px;
+    height: ${bannerHeight}px;
+    `}
 `;
 
 const Icon = styled(Clock)`

--- a/src/Containers/LoyaltyPoints/LoyaltyPoints.stories.tsx
+++ b/src/Containers/LoyaltyPoints/LoyaltyPoints.stories.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Meta, Story } from '@storybook/react';
+import { LoyaltyPointsProps, LoyaltyPoints } from '../../index';
+
+export default {
+
+    title: 'Components/LoyaltyPoints',
+    component: LoyaltyPoints,
+    args: {
+        loyaltyamount: 10,
+        loyaltypointlimit: 100,
+    }
+} as Meta;
+
+export const Basic: Story<LoyaltyPointsProps> = (args) => (
+    <LoyaltyPoints {...args} />
+)

--- a/src/Containers/LoyaltyPoints/LoyaltyPoints.tsx
+++ b/src/Containers/LoyaltyPoints/LoyaltyPoints.tsx
@@ -1,0 +1,42 @@
+﻿import React from 'react';
+import styled from 'styled-components';
+import { Stars } from '@styled-icons/material/Stars';
+
+export interface LoyaltyPointsProps
+    extends React.HTMLAttributes<HTMLDivElement> {
+    loyaltyamount: number; //the amount of loyalty points that the user gets with purchase, used to display on component.
+    loyaltypointlimit: number; //the limit of loyalty points before it says 99+ instead.
+}
+
+export const LoyaltyPoints: React.FC<LoyaltyPointsProps> = ({
+    loyaltyamount,
+    loyaltypointlimit,
+    ...props
+}): React.ReactElement => <LoyaltyPointsBox {...props}>
+    <header>+{getLoyaltyPoints(loyaltyamount, loyaltypointlimit)}<Star /></header>
+    </LoyaltyPointsBox>;
+
+function getLoyaltyPoints(loyaltypoints: number, loyaltypointlimit: number) {
+    if (loyaltypoints >= loyaltypointlimit) {
+        return loyaltypointlimit + "⁺";
+    }
+    return Math.round(loyaltypoints);
+}
+
+const LoyaltyPointsBox = styled.div`
+    ${({ theme }): string => `
+        font-family: ${theme.font.family};
+        font-size: 20px;
+        width: fit-content;
+        min-width: 60px;
+        height: 30px;
+        border-radius:0px 50px 50px 0px;
+        background-color: ${theme.colors.background};
+        color: ${theme.colors.loyaltyText};
+        text-align: center;
+    `}
+`
+const Star = styled(Stars)`
+    width: 20px;
+    height: 20px;
+`

--- a/src/Containers/MenuItemCard/MenuItemCard.stories.tsx
+++ b/src/Containers/MenuItemCard/MenuItemCard.stories.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { Meta, Story } from '@storybook/react';
+import { MenuItemCard, MenuItemCardProps, LoyaltyPoints, LimitedTimeBanner, SaleTag } from '../../index';
+
+export default {
+    title: 'Components/Menu Item Card',
+    component: MenuItemCard,
+    subcomponents: { LoyaltyPoints, LimitedTimeBanner, SaleTag },
+    argTypes: { onClick: { action: 'This card was clicked!' } },
+} as Meta;
+
+const Template: Story<MenuItemCardProps> = (args) => <MenuItemCard  {...args}> <LoyaltyPoints {...args} />
+    <LimitedTimeBanner {...args} />  <SaleTag {...args} /> </MenuItemCard>;
+
+export const MenuItemCardBasic = Template.bind({});
+MenuItemCardBasic.args = {
+    itemImage: 'https://keyassets-p2.timeincuk.net/wp/prod/wp-content/uploads/sites/63/2007/09/Ricotta-cheese-pancakes-with-blackberry-butter.jpg',
+    itemName: 'Blackberry Pancakes',
+    itemPrice: 15.99,
+    itemPriceLimit: 1000,
+    saleAmount: 5,
+    loyaltyamount: 20,
+    loyaltypointlimit: 100,
+    bannerWidth: 280,
+    bannerHeight: 40,
+    minsRemaining: 120,
+    sale: false,
+    soldOut: false,
+    animated: true,
+    flat: false,
+};
+
+export const MenuItemCardStates = Template.bind({});
+MenuItemCardStates.args = {
+    itemImage: 'https://keyassets-p2.timeincuk.net/wp/prod/wp-content/uploads/sites/63/2007/09/Ricotta-cheese-pancakes-with-blackberry-butter.jpg',
+    itemName: 'Blackberry Pancakes',
+    itemPrice: 15.99,
+    itemPriceLimit: 1000,
+    saleAmount: 5,
+    loyaltyamount: 0,
+    loyaltypointlimit: 100,
+    bannerWidth: 300,
+    bannerHeight: 40,
+    minsRemaining: 0,
+    sale: true,
+    soldOut: true,
+    animated: false,
+    flat: false,
+};
+
+export const MenuItemCardLongText = Template.bind({});
+MenuItemCardLongText.args = {
+    itemImage: 'https://keyassets-p2.timeincuk.net/wp/prod/wp-content/uploads/sites/63/2007/09/Ricotta-cheese-pancakes-with-blackberry-butter.jpg',
+    itemName: 'Super crazy long combo special order with extra sides and drinks',
+    itemPrice: 2560,
+    itemPriceLimit: 1000,
+    saleAmount: 200,
+    loyaltyamount: 1500,
+    loyaltypointlimit: 1200,
+    minsRemaining: 24000,
+    bannerWidth: 300,
+    bannerHeight: 40,
+    sale: true,
+    soldOut: false,
+    animated: true,
+    flat: false,
+};
+
+export const MenuItemCardEmpty = Template.bind({});
+MenuItemCardEmpty.args = {
+    itemImage: '',
+    itemName: '',
+    itemPrice: 0,
+    itemPriceLimit: 1000,
+    saleAmount: 0,
+    loyaltyamount: 0,
+    loyaltypointlimit: 100,
+    minsRemaining: 0,
+    bannerWidth: 300,
+    bannerHeight: 40,
+    sale: false,
+    soldOut: false,
+    animated: false,
+    flat: false,
+};
+

--- a/src/Containers/MenuItemCard/MenuItemCard.tsx
+++ b/src/Containers/MenuItemCard/MenuItemCard.tsx
@@ -1,0 +1,248 @@
+import React from 'react';
+import styled from 'styled-components';
+import { MainInterface, ResponsiveInterface } from '@Utils/BaseStyles';
+import { transition } from '@Utils/Mixins';
+import { LoyaltyPoints, LimitedTimeBanner, SaleTag } from '../../index';
+
+export interface MenuItemCardProps
+    extends MainInterface, ResponsiveInterface, React.HTMLAttributes<HTMLDivElement> {
+    /* Loyalty points component */
+    LoyaltyPoints?: React.ReactElement;
+    /* Limited time banner component*/
+    LimitedTimeBanner?: React.ReactElement;
+    /* Sale tag component */
+    SaleTag?: React.ReactElement;
+    /* Html link for the item, displayed as 280px x 125px*/
+    itemImage: string, 
+    /* Name of the product, after 30 characters '...' replaces the rest */
+    itemName: string,
+    /* Price of the item, is reduced by saleAmount if on sale and will be rounded by 1000 if above itemPriceLimit */
+    itemPrice: number, 
+    /* Limit before the item is rounded by 1000, should be greater than 1000 */
+    itemPriceLimit: number, 
+    /* Controls if the sale style is used and if a sale amount should be reduced */
+    sale: boolean;
+    /* Controls if the item can still be sold, also removes other components from card display */
+    soldOut: boolean;
+    /* Number passed to LoyaltyPoints to display the loyalty points amount */
+    loyaltyamount: number,
+    /* Limit before loyaltyPoints gets capped */
+    loyaltypointlimit: number,
+    /* Amount that the item is on sale, reduced from itemPrice when sale is active */
+    saleAmount: number,
+    /* Minutes that the item is remaining for, if 0 then will not display */
+    minsRemaining: number,
+    /* Width of the time remaining banner */
+    /* Add box shadow when hovered over */
+    animated?: boolean;
+    /* Controls the border around the menu item card, animated will still display the border when hovered over */
+    flat?: boolean;
+    bannerWidth?: number,
+    /* Height of the time remaining banner */
+    bannerHeight?: number,
+}
+
+export const MenuItemCard: React.FC<MenuItemCardProps> = ({
+    animated,
+    flat,
+    sale,
+    soldOut,
+    itemImage,
+    itemName,
+    itemPrice,
+    itemPriceLimit,
+    saleAmount,
+    loyaltyamount,
+    loyaltypointlimit,
+    minsRemaining,
+    bannerHeight,
+    bannerWidth,
+    ...props
+
+}): React.ReactElement => {
+    /**
+     * Checks the value of the item and checks for the sale and soldout states, then conditionally renders the item value based on the limit and states
+     * Item sale amount checks that the price of the sale won't lower the price of the item below 0, if it does, output 0
+     * @param sale - Indicates if the item is on sale
+     * @param soldOut - Indicates if the item is sold out
+     * @param itemPrice - The price of the item
+     * @param itemPriceLimit - Limit before using the roundItemValue function that returns rounded by 1000
+     * @param saleAmount - Amount reduced from the item if its on sale
+     */
+    function getMenuItemStatus(sale: boolean, soldOut: boolean, itemPrice: number, itemPriceLimit: number, saleAmount: number) {
+
+        var itemSaleAmount;
+        if (itemPrice - saleAmount > 0) {
+            itemSaleAmount = itemPrice - saleAmount
+        } else {
+            itemSaleAmount = 0;
+        }
+
+        if (itemPrice >= itemPriceLimit) {
+            return <PriceText1k>${roundItemValue(itemPrice, itemPriceLimit)}K+</PriceText1k>
+        } else if (sale) {
+            return <>
+                <PriceTextSlash>${itemPrice}</PriceTextSlash>
+                <OnSale>${itemSaleAmount}</OnSale>
+            </>
+        } else return <PriceText>${itemPrice}</PriceText>
+    }
+    /**
+     * Checks if item image has a value, then returns it or uses a defualt image
+     * @param itemImage - URL for the image, if left empty then return default image from below
+     * @param alt - Full name of the item
+     */
+    function getItemImage(itemImage: string, alt: string) {
+            if (!!itemImage) {
+                return <MenuItemCardImage src={itemImage} alt={itemName} />
+            } else return <MenuItemCardImage src='https://healthduel.net/healthduel/storage/app/game/GyeyqSeDD2qRmWJf8kocbK9YCtowBvgF4PZPsDlW.jpeg' alt={itemName} />
+    }
+    return (
+        <MenuItemCardBox {...props} bannerHeight={bannerHeight} itemImage={itemImage} itemName={itemName} itemPrice={itemPrice} animated={animated}
+            flat={flat} sale={sale} soldOut={soldOut} saleAmount={saleAmount} itemPriceLimit={itemPriceLimit}
+            loyaltyamount={loyaltyamount} minsRemaining={minsRemaining} loyaltypointlimit={loyaltypointlimit}>
+
+            <MenuItemCardAccessoryDiv>
+                {(!soldOut && !!loyaltyamount) &&
+                    <LoyaltyPoints loyaltyamount={loyaltyamount} loyaltypointlimit={loyaltypointlimit} />}
+                {(!soldOut && sale) &&
+                    <SaleTag saleAmount={saleAmount} />}
+            </MenuItemCardAccessoryDiv>
+
+            {getItemImage(itemImage, itemName)}
+
+            <MenuItemHeader>{getStringValue(itemName)}</MenuItemHeader>
+            {soldOut && <SoldOutBox>Sold Out</SoldOutBox>}
+
+            { (!!minsRemaining && !soldOut) &&
+                <LimitedTimeBannerPosition> <LimitedTimeBanner bannerHeight={bannerHeight} bannerWidth={bannerWidth} minsRemaining={minsRemaining} /> </LimitedTimeBannerPosition>}
+
+            {(!!itemPrice && !soldOut) && getMenuItemStatus(sale, soldOut, itemPrice, itemPriceLimit, saleAmount)}
+
+        </MenuItemCardBox>
+    );
+}
+/**
+ * Checks if the Item Price is greater than or equal to the item price limit
+ * Returns item price to the nearest tenth rounded
+ * Also reduces the amount by 1000, the K is added in the component
+ * @param itemPrice - Current price of the item displayed on the card
+ * @param itemPriceLimit - A threshold to hit before the item price starts being rounded 
+ */
+function roundItemValue(itemPrice: number, itemPriceLimit: number) {
+    if (itemPrice >= itemPriceLimit) {
+        return ((Math.round(itemPrice * .1) / .1) / 1000)
+    } else return itemPrice;
+};
+/**
+ * Returns the value of the string capped at 30 characters, and adds ... if that limit is hit
+ * @param itemName
+ */
+function getStringValue(itemName: string) {
+    var newString = itemName.substring(0, 30);
+    if (itemName.length > 30) {
+        return newString + '...';
+    } else
+        return newString;
+}
+
+const MenuItemCardBox = styled.div<MenuItemCardProps & MainInterface & ResponsiveInterface>`
+    position: relative; 
+    width: 300px;
+    height: 250px; 
+    z-index: 1; 
+    cursor: pointer;
+    box-shadow: ${({ flat, theme }): string => theme.depth[flat ? 0 : 1]}; 
+    
+    ${({ theme }): string => `
+    border-radius: ${theme.dimensions.radius};
+    background-color: ${theme.colors.background};
+    `}
+
+    ${({ animated, flat, theme, soldOut }): string =>
+        (animated && !soldOut) ? ` ${transition(['box-shadow'])} &:hover {
+            box-shadow: ${theme.depth[flat ? 1 : 2]};
+        }` : ''}
+
+    ${({ soldOut }) =>
+        soldOut && `
+      opacity: 0.5;
+      cursor: not-allowed; `}
+`;
+const MenuItemCardImage = styled.img`
+    height: 150px;
+    width: 300px;
+    ${({ theme }): string => `
+    border-top-left-radius: ${theme.dimensions.radius};
+    border-top-right-radius: ${theme.dimensions.radius};
+    `}
+`
+const SoldOutBox = styled.div`
+    ${({ theme }): string => `
+    font-family: ${theme.font.family};
+    color: ${theme.colors.background}};
+    background-color: ${theme.colors.menuItemCardSoldoutBox};
+    border-top-left-radius: ${theme.dimensions.radius};
+    border-top-right-radius: ${theme.dimensions.radius};
+    `}
+    position: absolute;
+    z-index: 2;
+    top: 0px;
+    font-size: 25px;
+    text-align: center;
+    width: 300px;
+    height: 40px; 
+    padding-top: 15px; 
+`;
+const MenuItemHeader = styled.header`
+    font-weight: bolder;
+    padding-left: 10px;
+    padding-bottom: 10px; 
+    padding-right: 120px;
+    font-size: 25px;  
+`
+const PriceText = styled.header`  
+    font-weight: bold; 
+    position: absolute;
+    font-size: 25px; 
+    text-align: right; 
+    right: 10px;
+    bottom: 40px; 
+`
+const PriceTextSlash = styled(PriceText)`
+    text-decoration: line-through;
+    font-size: 20px;
+    opacity: .6; 
+    bottom: 60px;
+    position: absolute;
+`
+const PriceText1k = styled(PriceText)`
+    font-size: 25px;
+    ${({ theme }): string => `
+    color: ${theme.colors.ItemCardSaleGreen};
+    `}
+`
+const OnSale = styled.header`
+    position: absolute;
+    font-size: 30px;
+    text-align: right;
+    font-weight: bold; 
+    ${({ theme }): string => `
+    color: ${theme.colors.primary};
+    `}
+    right: 10px;
+    bottom: 10px;
+`
+const MenuItemCardAccessoryDiv = styled.div`
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    position: absolute;
+    width: 100%;
+    top: 20px;
+    align-items: center;
+`
+const LimitedTimeBannerPosition = styled.div`
+    position: absolute;
+    top: 110px; 
+`

--- a/src/Containers/SaleTag/SaleTag.stories.tsx
+++ b/src/Containers/SaleTag/SaleTag.stories.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Meta, Story } from '@storybook/react';
 import { SaleTag, SaleTagProps } from '../../index';
 
-
 export default {
     title: 'Components/SaleTag',
     component: SaleTag,

--- a/src/Containers/SaleTag/SaleTag.tsx
+++ b/src/Containers/SaleTag/SaleTag.tsx
@@ -16,11 +16,12 @@ export const SaleTag: React.FC<SaleTagProps> = ({
     </SaleTagDiv>
 );
 
-const SaleTagDiv = styled.span`
+const SaleTagDiv = styled.div`
     ${({theme}):string => `
         border-radius: 100px;
-        width: 100px;
-        height: 40px;
+        width: fit-content;
+        min-width: 60px;
+        height: 20px;
         padding: 3px 10px;
         border-style: solid;
         border-width: 1px;

--- a/src/Containers/index.ts
+++ b/src/Containers/index.ts
@@ -95,3 +95,5 @@ export * from './LimitedTimeBanner/LimitedTimeBanner';
 export * from './TreeAccordion/TreeAccordion';
 export * from './ReachIndicator/ReachIndicator'; 
 export * from './InfoHeader/InfoHeader';
+export * from './MenuItemCard/MenuItemCard';
+export * from './LoyaltyPoints/LoyaltyPoints';

--- a/src/Themes/MainTheme.ts
+++ b/src/Themes/MainTheme.ts
@@ -31,12 +31,15 @@ export interface MainThemeInterface extends ThemeTemplateInterface {
         chairTableBackground: string;
         chairOccupiedBackground: string;
         chairTableEditBackground: string;
+        menuItemCardSoldoutBox: string;
         reachIndicatorColors: {
             red: string;
             yellow: string;
             green: string;
         };
+        loyaltyText: string;
         bannerBackgroundColor: string;
+        ItemCardSaleGreen: string;
     };
 }
 
@@ -66,7 +69,10 @@ export const MainTheme: MainThemeInterface = {
         chairTableBackground: '#6c757d',
         chairOccupiedBackground: '#EE2434',
         chairTableEditBackground: '#C4C4C4',
-        bannerBackgroundColor : 'rgba(0,0,0,0.5)',
+        bannerBackgroundColor: 'rgba(0,0,0,0.5)',
+        menuItemCardSoldoutBox: '#303030',
+        loyaltyText: '#0000FF',
+        ItemCardSaleGreen: '#04CC00',
         PieChartColors: {
             Red: '#FF0000',
             Green: '#008000',


### PR DESCRIPTION
New branch since the old one was on an old version of storybook and had other issues. Also added loyalty points since it was never merged to main. Made modifications to sale tag and limited time banner to make the dimensions adjustable and fit with my menu item card.  Added new functions to get values of item image and prices. Changed HTML so sale tag and loyalty points are aligned. 

https://user-images.githubusercontent.com/91333450/148624230-8484e7b6-5ddc-425c-b4d4-37ae47e921e3.mp4


