### PR TITLE
SpecialText

### DIFF
--- a/src/Containers/SpecialText/SpecialText.stories.tsx
+++ b/src/Containers/SpecialText/SpecialText.stories.tsx
@@ -1,0 +1,28 @@
+import { action } from '@storybook/addon-actions';
+import React from 'react';
+import { Meta, Story } from '@storybook/react';
+import { SpecialText, SpecialTextProps } from '../index';
+import { SmallText } from 'index';
+import styled from 'styled-components';
+
+const StyledSmallText = styled(SmallText)`
+    &: hover {
+        font-weight: bold;
+    }
+`;
+
+export default {
+    title: 'Components/SpecialText',
+    component: SpecialText,
+    args: {
+        text: 'Special Text',
+        children: [
+            <StyledSmallText onClick={action('Index 0')} children={'pie'}/>,
+            <StyledSmallText onClick={action('Index 1')} children={'world'}/>
+        ],
+    },
+} as Meta;
+
+export const Basic: Story<SpecialTextProps> = (args) => (
+    <SmallText>Here we introduce <SpecialText {...args}/></SmallText>
+);

--- a/src/Containers/SpecialText/SpecialText.tsx
+++ b/src/Containers/SpecialText/SpecialText.tsx
@@ -1,0 +1,61 @@
+import Dropdown from '../Dropdown/Dropdown';
+import DropdownItem from '../Dropdown/DropdownItem';
+import React, { Children, isValidElement } from 'react';
+import { SmallText } from 'index';
+import styled from 'styled-components';
+
+export interface SpecialTextProps {
+    text: string;
+    children: React.ReactNode[];
+    onChange?: Function;
+}
+
+const formatList = (
+    children: React.ReactNode[]
+    ): React.ReactNode[] => 
+    children.map((child): React.ReactElement | null => {
+        if (child && isValidElement(child)) {
+            const val = child.props.value;
+            return (
+                <DropdownItem 
+                    {...child.props}
+                    children={child} 
+                    key={val} 
+                    />
+            );
+        }
+        else return null;
+    });
+
+export const SpecialText: React.FC<SpecialTextProps> = ({
+    text,
+    children,
+    onChange = (): void => undefined,
+    ...props
+}): React.ReactElement => {
+    const options = Children.toArray(children)
+
+    return (
+        <StyledDiv {...props}>
+            <Dropdown dropdownButton={
+                <StyledDropDownText>{text}</StyledDropDownText>
+            }>
+                {formatList(options)}
+            </Dropdown>
+        </StyledDiv>
+    );
+};
+
+const StyledDiv = styled.div``;
+
+const StyledDropDownText = styled(SmallText)`
+    &:hover {
+        font-weight: bold;
+    }
+
+    ${({ theme }): string => `
+        color: ${theme.colors.statusColors.orange};
+    `}
+`;
+
+export default SpecialText;

--- a/src/Containers/index.ts
+++ b/src/Containers/index.ts
@@ -98,3 +98,4 @@ export * from './InfoHeader/InfoHeader';
 export * from './StoreSelector/StoreSelector'; 
 export * from './ScreenFlashEffect/ScreenFlashEffect'; 
 export * from './PanelCard/PanelCard';
+export * from './SpecialText/SpecialText';


### PR DESCRIPTION
Here is a demo:
https://user-images.githubusercontent.com/50276107/150618022-1ec81aa5-4b5c-4ce0-a4f7-994dea69be35.mp4
Comparing to `HighlightedText`, differences include:

- Removed isSpecial, textProps, listProps, listItemArgs, age
- Treated as a single word rather than a list (i.e. no opacity feature).
- No longer passes explicitly passes props
- No longer uses `ClickableSmallText`, `MainTheme`, `TextLayoutProps`, `IDropdownProps`, `IDropdownItemProps`, `useEffect`, `useState`.